### PR TITLE
Refactor Element integer API

### DIFF
--- a/element/dataset.go
+++ b/element/dataset.go
@@ -1,0 +1,41 @@
+package element
+
+import (
+	"encoding/binary"
+
+	"github.com/suyashkumar/dicom/dicomio"
+	"github.com/suyashkumar/dicom/dicomtag"
+)
+
+// DataSet represents contents of one DICOM file.
+type DataSet struct {
+	// Elements in the file, in order of appearance.
+	//
+	// Note: unlike pydicom, Elements also contains meta elements (those
+	// with Tag.Group==2).
+	Elements []*Element
+}
+
+// FindByName finds an element from the dataset given the element name,
+// such as "PatientName".
+func (f *DataSet) FindElementByName(name string) (*Element, error) {
+	return FindByName(f.Elements, name)
+}
+
+// FindByTag finds an element from the dataset given its tag, such as
+// Tag{0x0010, 0x0010}.
+func (f *DataSet) FindElementByTag(tag dicomtag.Tag) (*Element, error) {
+	return FindByTag(f.Elements, tag)
+}
+
+func (ds *DataSet) TransferSyntax() (bo binary.ByteOrder, implicit dicomio.IsImplicitVR, err error) {
+	elem, err := ds.FindElementByTag(dicomtag.TransferSyntaxUID)
+	if err != nil {
+		return nil, dicomio.UnknownVR, err
+	}
+	transferSyntaxUID, err := elem.GetString()
+	if err != nil {
+		return nil, dicomio.UnknownVR, err
+	}
+	return dicomio.ParseTransferSyntaxUID(transferSyntaxUID)
+}

--- a/write/writer_test.go
+++ b/write/writer_test.go
@@ -96,7 +96,7 @@ func TestNewElement(t *testing.T) {
 	elem, err := element.NewElement(dicomtag.TriggerSamplePosition, uint32(10), uint32(11))
 	require.NoError(t, err)
 	require.Equal(t, elem.Tag, dicomtag.TriggerSamplePosition)
-	require.Truef(t, reflect.DeepEqual(elem.MustGetUint32s(), []uint32{10, 11}),
+	require.Truef(t, reflect.DeepEqual(elem.MustGetInts(), []int64{10, 11}),
 		"Elem: %+v", elem)
 	// Pass a wrong value type.
 	elem, err = element.NewElement(dicomtag.TriggerSamplePosition, "foo")


### PR DESCRIPTION
This change refactors the API used to extract integer values from a DICOM `Element`. A top level API `GetInt` and `GetInts` retrieve the stored integer-like value (which may be `uint16`, `int8`, etc) consistently as either an `int64` or `[]int64`.

If the caller wants to access the "true" value of the integer(s), the caller can do so by directly accessing `Element.Value` and type casting as needed based on the Element's `VR`. 

All legacy methods to retrieve specific types of ints have been removed. 

There is some small-in-practice efficiency trade off to be typecasting these integers, but this API is clearer and easier to use and cleans up the code a fair bit. Power users can still easily work with the `Value`s directly if efficiency is of the utmost importance. 

This chance also factors out `DataSet` into its own file in the `element` package.