### PR TITLE
Add initial readElement, readSequence, and ElementPtrsValue

### DIFF
--- a/element.go
+++ b/element.go
@@ -36,6 +36,7 @@ const (
 	Strings ValueType = iota
 	Bytes
 	Ints
+	ElementPtrs
 )
 
 // Begin definitions of Values:
@@ -66,3 +67,12 @@ type IntsValue struct {
 func (s *IntsValue) isElementValue()       {}
 func (s *IntsValue) ValueType() ValueType  { return Ints }
 func (s *IntsValue) GetValue() interface{} { return s.value }
+
+// ElementPtrsValue represents a slice of pointers to other Elements (in the case of sequences)
+type ElementPtrsValue struct {
+	value []*Element
+}
+
+func (e *ElementPtrsValue) isElementValue()       {}
+func (e *ElementPtrsValue) ValueType() ValueType  { return ElementPtrs }
+func (e *ElementPtrsValue) GetValue() interface{} { return e.value }


### PR DESCRIPTION
This change introduces an initial implementation of readElement and readSequence. It also adds a new `Value` type for `Elements` called `ElementsPtrsValue` which is a slice of pointers to other (sub)Elements that may be part of an Element instance (e.g. if there's a sequence). 