### PR TITLE
Implement dicomio.Reader, add simple test program, fix some bugs

### DIFF
--- a/cmd/dicomtest/main.go
+++ b/cmd/dicomtest/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+
+	"github.com/suyashkumar/dicom"
+	"github.com/suyashkumar/dicom/pkg/tag"
+)
+
+var (
+	filepath = flag.String("path", "", "path")
+)
+
+func main() {
+	log.Println("start")
+	flag.Parse()
+	log.Println(*filepath)
+	if len(*filepath) > 0 {
+		log.Println("start")
+		f, err := os.Open(*filepath)
+		info, err := f.Stat()
+		if err != nil {
+			log.Println("err reading", err)
+		}
+		p, err := dicom.NewParser(f, info.Size())
+		if err != nil {
+			log.Println("err creating parser", err)
+		}
+		ds, err := p.Parse()
+		if err != nil {
+			log.Println("err parsing", err)
+		}
+		log.Println(len(ds.Elements))
+		for _, elem := range ds.Elements {
+			if elem.Tag != tag.PixelData {
+				log.Println(elem.Tag)
+				log.Println(elem.ValueLength)
+				log.Println(elem.Value)
+			}
+		}
+	}
+}

--- a/element.go
+++ b/element.go
@@ -94,5 +94,5 @@ func (e *ElementPtrsValue) ValueType() ValueType  { return ElementPtrs }
 func (e *ElementPtrsValue) GetValue() interface{} { return e.value }
 func (e *ElementPtrsValue) String() string {
 	// TODO: consider adding more sophisticated formatting
-	return fmt.Sprintf("%+v", e.value)
+	return ""
 }

--- a/element.go
+++ b/element.go
@@ -1,6 +1,8 @@
 package dicom
 
 import (
+	"fmt"
+
 	"github.com/suyashkumar/dicom/pkg/tag"
 )
 
@@ -21,12 +23,17 @@ type Element struct {
 	Value                  Value
 }
 
+func (e *Element) String() string {
+	return fmt.Sprintf("Tag:%s\nVR:%s\nValue:%s\n\n", e.Tag.String(), e.ValueRepresentation.String(), e.Value.String())
+}
+
 type Value interface {
 	// All types that can be a "Value" for an element will implement this empty method, similar to how protocol buffers
 	// implement "oneof" in Go
 	isElementValue()
 	ValueType() ValueType
 	GetValue() interface{} // TODO: rename to Get to read cleaner
+	String() string
 }
 
 type ValueType int
@@ -49,6 +56,9 @@ type BytesValue struct {
 func (b *BytesValue) isElementValue()       {}
 func (b *BytesValue) ValueType() ValueType  { return Bytes }
 func (b *BytesValue) GetValue() interface{} { return b.value }
+func (b *BytesValue) String() string {
+	return fmt.Sprintf("%v", b.value)
+}
 
 // StringsValue represents a value of []string.
 type StringsValue struct {
@@ -58,6 +68,9 @@ type StringsValue struct {
 func (s *StringsValue) isElementValue()       {}
 func (s *StringsValue) ValueType() ValueType  { return Strings }
 func (s *StringsValue) GetValue() interface{} { return s.value }
+func (s *StringsValue) String() string {
+	return fmt.Sprintf("%v", s.value)
+}
 
 // IntsValue represents a value of []int.
 type IntsValue struct {
@@ -67,6 +80,9 @@ type IntsValue struct {
 func (s *IntsValue) isElementValue()       {}
 func (s *IntsValue) ValueType() ValueType  { return Ints }
 func (s *IntsValue) GetValue() interface{} { return s.value }
+func (s *IntsValue) String() string {
+	return fmt.Sprintf("%v", s.value)
+}
 
 // ElementPtrsValue represents a slice of pointers to other Elements (in the case of sequences)
 type ElementPtrsValue struct {
@@ -76,3 +92,7 @@ type ElementPtrsValue struct {
 func (e *ElementPtrsValue) isElementValue()       {}
 func (e *ElementPtrsValue) ValueType() ValueType  { return ElementPtrs }
 func (e *ElementPtrsValue) GetValue() interface{} { return e.value }
+func (e *ElementPtrsValue) String() string {
+	// TODO: consider adding more sophisticated formatting
+	return fmt.Sprintf("%+v", e.value)
+}

--- a/mocks/pkg/dicomio/mock_reader.go
+++ b/mocks/pkg/dicomio/mock_reader.go
@@ -47,21 +47,6 @@ func (mr *MockReaderMockRecorder) Read(p interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockReader)(nil).Read), p)
 }
 
-// ReadN mocks base method
-func (m *MockReader) ReadN(n uint32) ([]byte, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadN", n)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ReadN indicates an expected call of ReadN
-func (mr *MockReaderMockRecorder) ReadN(n interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadN", reflect.TypeOf((*MockReader)(nil).ReadN), n)
-}
-
 // ReadUInt16 mocks base method
 func (m *MockReader) ReadUInt16() (uint16, error) {
 	m.ctrl.T.Helper()
@@ -152,7 +137,7 @@ func (mr *MockReaderMockRecorder) Skip(n interface{}) *gomock.Call {
 }
 
 // PushLimit mocks base method
-func (m *MockReader) PushLimit(n int) {
+func (m *MockReader) PushLimit(n int64) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "PushLimit", n)
 }
@@ -187,4 +172,18 @@ func (m *MockReader) IsLimitExhausted() bool {
 func (mr *MockReaderMockRecorder) IsLimitExhausted() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsLimitExhausted", reflect.TypeOf((*MockReader)(nil).IsLimitExhausted))
+}
+
+// BytesLeftUntilLimit mocks base method
+func (m *MockReader) BytesLeftUntilLimit() int64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BytesLeftUntilLimit")
+	ret0, _ := ret[0].(int64)
+	return ret0
+}
+
+// BytesLeftUntilLimit indicates an expected call of BytesLeftUntilLimit
+func (mr *MockReaderMockRecorder) BytesLeftUntilLimit() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BytesLeftUntilLimit", reflect.TypeOf((*MockReader)(nil).BytesLeftUntilLimit))
 }

--- a/mocks/pkg/dicomio/mock_reader.go
+++ b/mocks/pkg/dicomio/mock_reader.go
@@ -137,9 +137,11 @@ func (mr *MockReaderMockRecorder) Skip(n interface{}) *gomock.Call {
 }
 
 // PushLimit mocks base method
-func (m *MockReader) PushLimit(n int64) {
+func (m *MockReader) PushLimit(n int64) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "PushLimit", n)
+	ret := m.ctrl.Call(m, "PushLimit", n)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // PushLimit indicates an expected call of PushLimit

--- a/mocks/pkg/dicomio/mock_reader.go
+++ b/mocks/pkg/dicomio/mock_reader.go
@@ -123,7 +123,7 @@ func (mr *MockReaderMockRecorder) ReadString(n interface{}) *gomock.Call {
 }
 
 // Skip mocks base method
-func (m *MockReader) Skip(n uint) error {
+func (m *MockReader) Skip(n int64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Skip", n)
 	ret0, _ := ret[0].(error)

--- a/parse.go
+++ b/parse.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
+	"log"
 	"os"
 
 	"github.com/suyashkumar/dicom/pkg/dicomio"
@@ -49,7 +50,7 @@ func NewParser(in io.Reader, bytesToRead int64) (Parser, error) {
 
 	p.dataset = Dataset{Elements: elems}
 
-	return nil, nil
+	return &p, nil
 }
 
 func NewParserFromBytes(data []byte) (Parser, error) {
@@ -61,6 +62,7 @@ func (p *parser) readHeader() ([]*Element, error) {
 	// Must read as LittleEndian explicit VR
 	err := p.reader.Skip(128) // skip preamble
 	if err != nil {
+		log.Println("skip er")
 		return nil, err
 	}
 
@@ -72,6 +74,7 @@ func (p *parser) readHeader() ([]*Element, error) {
 	// Read the length of the metadata elements: (0002,0000) MetaElementGroupLength
 	maybeMetaLen, err := readElement(p.reader)
 	if err != nil {
+		log.Println("read element err")
 		return nil, err
 	}
 
@@ -79,27 +82,29 @@ func (p *parser) readHeader() ([]*Element, error) {
 		return nil, ErrorMetaElementGroupLength
 	}
 
-	metaLen := maybeMetaLen.Value.GetValue().(IntsValue).value[0]
+	metaLen := maybeMetaLen.Value.GetValue().([]int)[0]
 
 	metaElems := []*Element{maybeMetaLen} // TODO: maybe set capacity to a reasonable initial size
 
 	// Read the metadata elements
-	p.reader.PushLimit(metaLen)
+	p.reader.PushLimit(int64(metaLen))
 	defer p.reader.PopLimit()
 	for !p.reader.IsLimitExhausted() {
 		elem, err := readElement(p.reader)
 		if err != nil {
 			// TODO: see if we can skip over malformed elements somehow
+			log.Println("read element err")
+
 			return nil, err
 		}
+		log.Printf("Metadata Element: %s\n", elem)
 		metaElems = append(metaElems, elem)
 	}
-
 	return metaElems, nil
 }
 
 func (p *parser) Parse() (Dataset, error) {
-	for p.reader.IsLimitExhausted() {
+	for !p.reader.IsLimitExhausted() {
 		// TODO: avoid silent looping
 		elem, err := readElement(p.reader)
 		if err != nil {
@@ -113,5 +118,5 @@ func (p *parser) Parse() (Dataset, error) {
 		p.dataset.Elements = append(p.dataset.Elements, elem)
 	}
 
-	return Dataset{}, nil
+	return p.dataset, nil
 }

--- a/parse.go
+++ b/parse.go
@@ -87,7 +87,10 @@ func (p *parser) readHeader() ([]*Element, error) {
 	metaElems := []*Element{maybeMetaLen} // TODO: maybe set capacity to a reasonable initial size
 
 	// Read the metadata elements
-	p.reader.PushLimit(int64(metaLen))
+	err = p.reader.PushLimit(int64(metaLen))
+	if err != nil {
+		return nil, err
+	}
 	defer p.reader.PopLimit()
 	for !p.reader.IsLimitExhausted() {
 		elem, err := readElement(p.reader)

--- a/pkg/dicomio/reader.go
+++ b/pkg/dicomio/reader.go
@@ -2,8 +2,13 @@ package dicomio
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
+)
+
+var (
+	ErrorBytesNotAvailable = errors.New("asked for more bytes than available in this reader (based on current limit)")
 )
 
 type Reader interface {
@@ -93,7 +98,7 @@ func (r *reader) ReadInt32() (int32, error) {
 }
 func (r *reader) ReadString(n uint32) (string, error) {
 	data := make([]byte, n)
-	_, err := r.Read(data)
+	_, err := io.ReadFull(r, data)
 	// TODO: add support for different coding systems
 	return string(data), err
 }

--- a/pkg/dicomio/reader.go
+++ b/pkg/dicomio/reader.go
@@ -2,13 +2,8 @@ package dicomio
 
 import (
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"io"
-)
-
-var (
-	ErrorBytesNotAvailable = errors.New("asked for more bytes than available in this reader (based on current limit)")
 )
 
 type Reader interface {
@@ -48,22 +43,18 @@ func (r *reader) BytesLeftUntilLimit() int64 {
 
 // Read
 func (r *reader) Read(p []byte) (int, error) {
-	//fmt.Println("bytes left", r.BytesLeftUntilLimit())
-	//fmt.Println("bytes asked", len(p))
 	// Check if we've hit the limit
 	if r.BytesLeftUntilLimit() <= 0 {
 		if len(p) == 0 {
 			return 0, nil
 		}
-		fmt.Println("bytes left", r.BytesLeftUntilLimit())
-		fmt.Println("bytes asked", len(p))
 		return 0, io.EOF
 	}
 
 	// If asking for more than we have left, just return whatever we've got left
 	// TODO: return a special kind of error if this situation occurs to inform the caller
 	if int64(len(p)) > r.BytesLeftUntilLimit() {
-		p = p[:r.limit]
+		p = p[:r.BytesLeftUntilLimit()]
 	}
 	n, err := r.in.Read(p)
 	if n >= 0 {

--- a/read.go
+++ b/read.go
@@ -28,7 +28,7 @@ func readTag(r dicomio.Reader) (*tag.Tag, error) {
 // TODO: Parsed VR should be an enum. Will require refactors of tag pkg.
 func readVR(r dicomio.Reader, isImplicit bool, t tag.Tag) (string, error) {
 	if isImplicit {
-		if entry, err := tag.Find(t); err != nil {
+		if entry, err := tag.Find(t); err == nil {
 			return entry.VR, nil
 		}
 		return tag.UNKNOWN, nil

--- a/read.go
+++ b/read.go
@@ -118,7 +118,10 @@ func readSequence(r dicomio.Reader, t tag.Tag, vr string, vl uint32) (Value, err
 		}
 	} else {
 		// Sequence of elements for a total of VL bytes
-		r.PushLimit(int64(vl))
+		err := r.PushLimit(int64(vl))
+		if err != nil {
+			return nil, err
+		}
 		for !r.IsLimitExhausted() {
 			subElem, err := readElement(r)
 			if err != nil {

--- a/read.go
+++ b/read.go
@@ -60,7 +60,7 @@ func readVL(r dicomio.Reader, isImplicit bool, t tag.Tag, vr string) (uint32, er
 		}
 		return vl, nil
 	default:
-		vl16, err := r.ReadUInt32()
+		vl16, err := r.ReadUInt16()
 		if err != nil {
 			return 0, err
 		}
@@ -71,10 +71,6 @@ func readVL(r dicomio.Reader, isImplicit bool, t tag.Tag, vr string) (uint32, er
 		}
 		return vl, nil
 	}
-}
-
-func readRawValue(r dicomio.Reader, vl uint32) ([]byte, error) {
-	return r.ReadN(vl)
 }
 
 func readValue(r dicomio.Reader, t tag.Tag, vr string, vl uint32, isImplicit bool) (Value, error) {
@@ -92,6 +88,8 @@ func readValue(r dicomio.Reader, t tag.Tag, vr string, vl uint32, isImplicit boo
 		return readInt(r, t, vr, vl)
 	case tag.VRSequence:
 		return readSequence(r, t, vr, vl)
+	default:
+		return readString(r, t, vr, vl)
 	}
 
 	return nil, fmt.Errorf("unsure how to parse this VR")
@@ -120,7 +118,7 @@ func readSequence(r dicomio.Reader, t tag.Tag, vr string, vl uint32) (Value, err
 		}
 	} else {
 		// Sequence of elements for a total of VL bytes
-		r.PushLimit(int(vl))
+		r.PushLimit(int64(vl))
 		for !r.IsLimitExhausted() {
 			subElem, err := readElement(r)
 			if err != nil {


### PR DESCRIPTION
This change implements the initial `dicomio.Reader`, which unblocks the first end-to-end test of the rewritten prototype parser. A simple test program was added to test the library, which appears to successfully parse several simple test DICOMs!

Several bugs were also caught and fixed. 

More robust e2e testing against a suite of public DICOMs should be added, in addition to more comprehensive unit testing as this rewritten library begins to take shape. 

Since this is on the rewrite branch, going to submit this to continue moving forward and building out a prototype rewrite.