### PR TITLE
[Rewritten Prototype] Implement SQ Item parsing

### DIFF
--- a/element.go
+++ b/element.go
@@ -44,7 +44,6 @@ const (
 	Strings ValueType = iota
 	Bytes
 	Ints
-	ElementPtrs
 	PixelData
 	SequenceItem
 	Sequences

--- a/element.go
+++ b/element.go
@@ -46,6 +46,8 @@ const (
 	Ints
 	ElementPtrs
 	PixelData
+	SequenceItem
+	Sequences
 )
 
 // Begin definitions of Values:
@@ -86,17 +88,29 @@ func (s *IntsValue) String() string {
 	return fmt.Sprintf("%v", s.value)
 }
 
-// ElementPtrsValue represents a slice of pointers to other Elements (in the case of sequences)
-type ElementPtrsValue struct {
-	value []*Element
+type SequenceItemValue struct {
+	elements []*Element
 }
 
-func (e *ElementPtrsValue) isElementValue()       {}
-func (e *ElementPtrsValue) ValueType() ValueType  { return ElementPtrs }
-func (e *ElementPtrsValue) GetValue() interface{} { return e.value }
-func (e *ElementPtrsValue) String() string {
+func (s *SequenceItemValue) isElementValue()       {}
+func (s *SequenceItemValue) ValueType() ValueType  { return SequenceItem }
+func (s *SequenceItemValue) GetValue() interface{} { return s.elements }
+func (s *SequenceItemValue) String() string {
 	// TODO: consider adding more sophisticated formatting
-	return ""
+	return fmt.Sprintf("%+v", s.elements)
+}
+
+// SequencesValue represents a set of items in a DICOM sequence.
+type SequencesValue struct {
+	value []*SequenceItemValue
+}
+
+func (s *SequencesValue) isElementValue()       {}
+func (s *SequencesValue) ValueType() ValueType  { return Sequences }
+func (s *SequencesValue) GetValue() interface{} { return s.value }
+func (s *SequencesValue) String() string {
+	// TODO: consider adding more sophisticated formatting
+	return fmt.Sprintf("%+v", s.value)
 }
 
 type PixelDataInfo struct {

--- a/parse.go
+++ b/parse.go
@@ -115,6 +115,8 @@ func (p *parser) Parse() (Dataset, error) {
 			return Dataset{}, err
 		}
 
+		log.Println("Read tag: ", elem.Tag)
+
 		// TODO: if we encounter a dicomtag.SpecificCharacterSet, update the reader to accommodate
 		// TODO: add dicom options to only keep track of certain tags
 

--- a/read.go
+++ b/read.go
@@ -147,7 +147,6 @@ func readSequence(r dicomio.Reader, t tag.Tag, vr string, vl uint32) (Value, err
 	if vl == tag.VLUndefinedLength {
 		for {
 			subElement, err := readElement(r)
-			// log.Println("read subelement (undeflen) with tag ", subElement.Tag)
 			if err != nil {
 				// Stop reading due to error
 				log.Println("error reading subitem, ", err)
@@ -174,7 +173,6 @@ func readSequence(r dicomio.Reader, t tag.Tag, vr string, vl uint32) (Value, err
 		}
 		for !r.IsLimitExhausted() {
 			subElement, err := readElement(r)
-			log.Println("read subelement with tag ", subElement.Tag)
 			if err != nil {
 				// TODO: option to ignore errors parsing subelements?
 				return nil, err
@@ -222,7 +220,6 @@ func readSequenceItem(r dicomio.Reader, t tag.Tag, vr string, vl uint32) (Value,
 		}
 	}
 
-	log.Println("Sequence Item", sequenceItem)
 	return &sequenceItem, nil
 }
 


### PR DESCRIPTION
This change implements correct parsing of sequence elements. More details on the structure of nested items can be found at the [standard here](http://dicom.nema.org/dicom/2013/output/chtml/part05/sect_7.5.html).

Previously, the complete SQ items were read, but not parsed correctly into sequence items. 

This change also added support for additional integer VR parsing. 