### PR TITLE
Explicitly close file on error in NewParserFromFile

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -68,10 +68,12 @@ func NewParserFromFile(path string, frameChannel chan *frame.Frame) (Parser, err
 	}
 	st, err := file.Stat()
 	if err != nil {
+		file.Close()
 		return nil, err
 	}
 	p, err := NewParser(file, st.Size(), frameChannel)
 	if err != nil {
+		file.Close()
 		return nil, err
 	}
 	p.(*parser).file = file


### PR DESCRIPTION
There are 2 potential fixes in the PR. The first (as commit 'Simplest Fix') is to leave `NewParserFromFile` mostly the same and add close the file before returning from the function with an error. The second fix (as 'Issue #66 better fix', which is named incorrectly and should be issue #75) is to utilize the helper function `NewParserFromBytes` to allow the function `NewParserFromFile` to open and close the relevant file within the function and not have to worry about managing open files later. 

