### PR TITLE
Support parsing NativePixelData when it appears multiple times in a DICOM

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -32,11 +32,13 @@ type Parser interface {
 
 // parser implements Parser
 type parser struct {
-	decoder                *dicomio.Decoder
-	parsedElements         *element.DataSet
-	op                     ParseOptions
-	frameChannel           chan *frame.Frame
-	file                   *os.File // may be populated if coming from file
+	decoder        *dicomio.Decoder
+	parsedElements *element.DataSet
+	op             ParseOptions
+	frameChannel   chan *frame.Frame
+	file           *os.File // may be populated if this parser is coming from a file
+	// currentSequenceDataset is populated with Elements read so far in a SQ DICOM sequence (or is nil if not currently
+	// reading a sequence).
 	currentSequenceDataset *element.DataSet
 }
 


### PR DESCRIPTION
This fixes #77 and appears to work on provided DICOMs. This is a relatively quick fix, that does seem to get the job done. There are some minor improvements that can be made in future PRs, but it will be best to get these changes in to unblock future work. 

This also appears to fix #82, and fix #65 (we are able to parse those images without errors).

For most of the provided images, the issue was that an icon image sequence could appear in the DICOMs in addition to the primary PixelData. When reading that particular image sequence, a different set of metadata tags need to be used (instead of the global ones, which apply only to the core PixelData).

There may be additional work to fully and correctly parsing icon image sets (most of the icons seem to be unpopulated in the sample images), but this change will at least prevent the parser from failing on DICOMs like this.