### PR TITLE
write: pad certain VRs with spaces instead of null bytes

### DIFF
--- a/write/writer.go
+++ b/write/writer.go
@@ -384,7 +384,14 @@ func Element(e *dicomio.Encoder, elem *element.Element, opts ...Option) {
 			}
 			sube.WriteString(s)
 			if len(s)%2 == 1 {
-				sube.WriteByte(0)
+				switch vr {
+				// Values with VRs constructed of character strings, except in the case of the VR UI, shall be padded with SPACE characters
+				// per http://dicom.nema.org/medical/dicom/current/output/html/part05.html#sect_6.2
+				case "DT", "LO", "LT", "PN", "SH", "ST", "UT":
+					sube.WriteString(" ")
+				default:
+					sube.WriteByte(0)
+				}
 			}
 		}
 		if sube.Error() != nil {


### PR DESCRIPTION
`make` output:

```
make
go mod download
/Library/Developer/CommandLineTools/usr/bin/make test
go test ./...
ok  	github.com/suyashkumar/dicom	0.389s
?   	github.com/suyashkumar/dicom/cmd/dicomutil	[no test files]
?   	github.com/suyashkumar/dicom/constants	[no test files]
ok  	github.com/suyashkumar/dicom/dicomio	(cached)
?   	github.com/suyashkumar/dicom/dicomlog	[no test files]
ok  	github.com/suyashkumar/dicom/dicomtag	(cached)
ok  	github.com/suyashkumar/dicom/dicomuid	(cached)
?   	github.com/suyashkumar/dicom/element	[no test files]
?   	github.com/suyashkumar/dicom/frame	[no test files]
ok  	github.com/suyashkumar/dicom/query	0.018s
ok  	github.com/suyashkumar/dicom/write	(cached)
go build -o build/dicomutil ./cmd/dicomutil
```

On the DICOM file where I experience issue 80, reading the DICOM file with `suyashkumar/dicom`, and then making an exact copy with this library, I get the following differences when opening in Pydicom:

```
In [8]: a = pydicom.dcmread(a_fp)                                                                                                       

In [9]: b = pydicom.dcmread(b_fp)                                                                                                       

In [10]: a.RequestAttributesSequence[0]                                                                                                 
Out[10]: 
(0040, 0007) Scheduled Procedure Step Descriptio LO: 'G2702'
(0040, 0009) Scheduled Procedure Step ID         SH: 'G2702'
(0040, 1001) Requested Procedure ID              SH: '918081'

In [11]: b.RequestAttributesSequence[0]                                                                                                 
Out[11]: 
(0040, 0007) Scheduled Procedure Step Descriptio LO: 'G2702\x00'
(0040, 0009) Scheduled Procedure Step ID         SH: 'G2702\x00'
(0040, 1001) Requested Procedure ID              SH: '918081'
```

After the fix in this PR, and running the same experiment, these fields are now identical in `pydicom`:

```
In [6]: a.RequestAttributesSequence[0]                                                                                                  
Out[6]: 
(0040, 0007) Scheduled Procedure Step Descriptio LO: 'G2702'
(0040, 0009) Scheduled Procedure Step ID         SH: 'G2702'
(0040, 1001) Requested Procedure ID              SH: '918081'

In [7]: b.RequestAttributesSequence[0]                                                                                                  
Out[7]: 
(0040, 0007) Scheduled Procedure Step Descriptio LO: 'G2702'
(0040, 0009) Scheduled Procedure Step ID         SH: 'G2702'
(0040, 1001) Requested Procedure ID              SH: '918081'
```

No more extra NULL byte `\x00`.
