### PR TITLE
[Rewrite] Native Pixel Data Parsing, handle value multiplicity.

### DIFF
--- a/cmd/dicomtest/main.go
+++ b/cmd/dicomtest/main.go
@@ -4,7 +4,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"image/jpeg"
 	"log"
 	"os"
 
@@ -51,9 +51,18 @@ func main() {
 				log.Println(elem.Value)
 			} else {
 				imageInfo := elem.Value.GetValue().(dicom.PixelDataInfo)
-				for i, frame := range imageInfo.Frames {
-					err := ioutil.WriteFile(fmt.Sprintf("image_%d.jpg", i), frame.EncapsulatedData.Data,
-						0644)
+				for idx, f := range imageInfo.Frames {
+					i, err := f.GetImage()
+					if err != nil {
+						log.Fatal("Error while getting image")
+					}
+
+					name := fmt.Sprintf("image_%d.jpg", idx)
+					f, err := os.Create(name)
+					if err != nil {
+						fmt.Printf("Error while creating file: %s", err.Error())
+					}
+					err = jpeg.Encode(f, i, &jpeg.Options{Quality: 100})
 					if err != nil {
 						log.Println(err)
 					}

--- a/cmd/dicomtest/main.go
+++ b/cmd/dicomtest/main.go
@@ -85,5 +85,9 @@ func writePixelDataElement(e *dicom.Element, id string) {
 		if err != nil {
 			log.Println(err)
 		}
+		if err = f.Close(); err != nil {
+			log.Println("ERROR: unable to properly close file: ", f.Name())
+		}
+
 	}
 }

--- a/dataset.go
+++ b/dataset.go
@@ -22,14 +22,3 @@ func (d *Dataset) FindElementByTag(tag tag.Tag) (*Element, error) {
 	}
 	return nil, ErrorElementNotFound
 }
-
-/*
-type FlatDatasetIterator struct {
-	ElementsPtr *[]*Element
-}
-
-// Next returns the next element when iterating through the flattened dataset (which means even recursively
-func (f FlatDatasetIterator) Next() (*Element, error) {
-
-}
-*/

--- a/dataset.go
+++ b/dataset.go
@@ -1,6 +1,35 @@
 package dicom
 
+import (
+	"errors"
+
+	"github.com/suyashkumar/dicom/pkg/tag"
+)
+
+var ErrorElementNotFound = errors.New("element not found")
+
 type Dataset struct {
 	Elements []*Element
-	Size     uint64
 }
+
+// FindElementByTag searches through the dataset and returns a pointer to the matching element.
+// It DOES NOT search within Sequences as well.
+func (d *Dataset) FindElementByTag(tag tag.Tag) (*Element, error) {
+	for _, e := range d.Elements {
+		if e.Tag == tag {
+			return e, nil
+		}
+	}
+	return nil, ErrorElementNotFound
+}
+
+/*
+type FlatDatasetIterator struct {
+	ElementsPtr *[]*Element
+}
+
+// Next returns the next element when iterating through the flattened dataset (which means even recursively
+func (f FlatDatasetIterator) Next() (*Element, error) {
+
+}
+*/

--- a/element.go
+++ b/element.go
@@ -130,3 +130,15 @@ func (e *PixelDataValue) String() string {
 	// TODO: consider adding more sophisticated formatting
 	return ""
 }
+
+func MustGetInt(v Value) int {
+	return v.GetValue().([]int)[0]
+}
+
+func MustGetInts(v Value) []int {
+	return v.GetValue().([]int)
+}
+
+func MustGetString(v Value) string {
+	return v.GetValue().([]string)[0]
+}

--- a/mocks/pkg/dicomio/mock_reader.go
+++ b/mocks/pkg/dicomio/mock_reader.go
@@ -47,6 +47,21 @@ func (mr *MockReaderMockRecorder) Read(p interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockReader)(nil).Read), p)
 }
 
+// ReadUInt8 mocks base method
+func (m *MockReader) ReadUInt8() (uint8, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadUInt8")
+	ret0, _ := ret[0].(uint8)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadUInt8 indicates an expected call of ReadUInt8
+func (mr *MockReaderMockRecorder) ReadUInt8() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadUInt8", reflect.TypeOf((*MockReader)(nil).ReadUInt8))
+}
+
 // ReadUInt16 mocks base method
 func (m *MockReader) ReadUInt16() (uint16, error) {
 	m.ctrl.T.Helper()

--- a/parse.go
+++ b/parse.go
@@ -72,7 +72,7 @@ func (p *parser) readHeader() ([]*Element, error) {
 	}
 
 	// Read the length of the metadata elements: (0002,0000) MetaElementGroupLength
-	maybeMetaLen, err := readElement(p.reader)
+	maybeMetaLen, err := readElement(p.reader, nil)
 	if err != nil {
 		log.Println("read element err")
 		return nil, err
@@ -93,7 +93,7 @@ func (p *parser) readHeader() ([]*Element, error) {
 	}
 	defer p.reader.PopLimit()
 	for !p.reader.IsLimitExhausted() {
-		elem, err := readElement(p.reader)
+		elem, err := readElement(p.reader, nil)
 		if err != nil {
 			// TODO: see if we can skip over malformed elements somehow
 			log.Println("read element err")
@@ -109,7 +109,7 @@ func (p *parser) readHeader() ([]*Element, error) {
 func (p *parser) Parse() (Dataset, error) {
 	for !p.reader.IsLimitExhausted() {
 		// TODO: avoid silent looping
-		elem, err := readElement(p.reader)
+		elem, err := readElement(p.reader, &p.dataset)
 		if err != nil {
 			// TODO: tolerate some kinds of errors and continue parsing
 			return Dataset{}, err

--- a/pkg/dicomio/reader.go
+++ b/pkg/dicomio/reader.go
@@ -15,6 +15,8 @@ var (
 // Reader provides common functionality for reading underlying DICOM data.
 type Reader interface {
 	io.Reader
+	// ReadUInt8 reads a uint16 from the underlying reader
+	ReadUInt8() (uint8, error)
 	// ReadUInt16 reads a uint16 from the underlying reader
 	ReadUInt16() (uint16, error)
 	// ReadUInt32 reads a uint32 from the underlying reader
@@ -78,6 +80,12 @@ func (r *reader) Read(p []byte) (int, error) {
 		r.bytesRead += int64(n)
 	}
 	return n, err
+}
+
+func (r *reader) ReadUInt8() (uint8, error) {
+	var out uint8
+	err := binary.Read(r, r.bo, &out)
+	return out, err
 }
 
 func (r *reader) ReadUInt16() (uint16, error) {


### PR DESCRIPTION
This implements native pixel data parsing on the rewrite branch. This includes fixes done on the mainline branch to parse PixelData properly if it appears multiple times in a DICOM (PR #79). This also includes some fixes to better handle value multiplicity. 