### PR TITLE
[Rewrite] Port over support for character sets

### DIFF
--- a/element.go
+++ b/element.go
@@ -142,3 +142,7 @@ func MustGetInts(v Value) []int {
 func MustGetString(v Value) string {
 	return v.GetValue().([]string)[0]
 }
+
+func MustGetStrings(v Value) []string {
+	return v.GetValue().([]string)
+}

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.13
 require (
 	github.com/golang/mock v1.3.1
 	github.com/stretchr/testify v1.4.0
+	golang.org/x/text v0.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,7 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262 h1:qsl9y/CJx34tuA7QCPNp86JNJe4spst6Ff8MjvPUdPg=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=

--- a/mocks/pkg/dicomio/mock_reader.go
+++ b/mocks/pkg/dicomio/mock_reader.go
@@ -7,6 +7,7 @@ package mock_dicomio
 import (
 	binary "encoding/binary"
 	gomock "github.com/golang/mock/gomock"
+	charset "github.com/suyashkumar/dicom/pkg/charset"
 	reflect "reflect"
 )
 
@@ -230,4 +231,16 @@ func (m *MockReader) IsImplicit() bool {
 func (mr *MockReaderMockRecorder) IsImplicit() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsImplicit", reflect.TypeOf((*MockReader)(nil).IsImplicit))
+}
+
+// SetCodingSystem mocks base method
+func (m *MockReader) SetCodingSystem(cs charset.CodingSystem) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetCodingSystem", cs)
+}
+
+// SetCodingSystem indicates an expected call of SetCodingSystem
+func (mr *MockReaderMockRecorder) SetCodingSystem(cs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCodingSystem", reflect.TypeOf((*MockReader)(nil).SetCodingSystem), cs)
 }

--- a/parse.go
+++ b/parse.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/suyashkumar/dicom/pkg/charset"
 	"github.com/suyashkumar/dicom/pkg/dicomio"
 	"github.com/suyashkumar/dicom/pkg/tag"
 	"github.com/suyashkumar/dicom/pkg/uid"
@@ -130,10 +131,21 @@ func (p *parser) Parse() (Dataset, error) {
 
 		log.Println("Read tag: ", elem.Tag)
 
-		// TODO: if we encounter a dicomtag.SpecificCharacterSet, update the reader to accommodate
 		// TODO: add dicom options to only keep track of certain tags
 
+		if elem.Tag == tag.SpecificCharacterSet {
+			encodingNames := MustGetStrings(elem.Value)
+			cs, err := charset.ParseSpecificCharacterSet(encodingNames)
+			if err != nil {
+				// unable to parse character set, hard error
+				// TODO: add option continue, even if unable to parse
+				return p.dataset, err
+			}
+			p.reader.SetCodingSystem(cs)
+		}
+
 		p.dataset.Elements = append(p.dataset.Elements, elem)
+
 	}
 
 	return p.dataset, nil

--- a/pkg/charset/charset.go
+++ b/pkg/charset/charset.go
@@ -1,0 +1,108 @@
+package charset
+
+import (
+	"fmt"
+
+	"golang.org/x/text/encoding"
+	"golang.org/x/text/encoding/htmlindex"
+)
+
+// CodingSystem defines how a DICOM []byte is translated into a utf8 string.
+type CodingSystem struct {
+	// VR="PN" is the only place where we potentially use all three
+	// decoders.  For all other VR types, only Ideographic decoder is used.
+	// See P3.5, 6.2.
+	//
+	// P3.5 6.1 is supposed to define the coding systems in detail.  But the
+	// spec text is insanely obtuse and I couldn't tell what its meaning
+	// after hours of trying. So I just copied what pydicom charset.py is
+	// doing.
+	Alphabetic  *encoding.Decoder
+	Ideographic *encoding.Decoder
+	Phonetic    *encoding.Decoder
+}
+
+// CodingSystemType defines the where the coding system is going to be
+// used. This distinction is useful in Japanese, but of little use in other
+// languages.
+type CodingSystemType int
+
+const (
+	// AlphabeticCodingSystem is for writing a name in (English) alphabets.
+	AlphabeticCodingSystem CodingSystemType = iota
+	// IdeographicCodingSystem is for writing the name in the native writing
+	// system (Kanji).
+	IdeographicCodingSystem
+	// PhoneticCodingSystem is for hirakana and/or katakana.
+	PhoneticCodingSystem
+)
+
+// htmlEncodingNames represents a mapping of DICOM charset name to golang encoding/htmlindex name.  "" means
+// 7bit ascii.
+var htmlEncodingNames = map[string]string{
+	"ISO_IR 6":        "iso-8859-1",
+	"ISO 2022 IR 6":   "iso-8859-1",
+	"ISO_IR 13":       "shift_jis",
+	"ISO 2022 IR 13":  "shift_jis",
+	"ISO_IR 100":      "iso-8859-1",
+	"ISO 2022 IR 100": "iso-8859-1",
+	"ISO_IR 101":      "iso-8859-2",
+	"ISO 2022 IR 101": "iso-8859-2",
+	"ISO_IR 109":      "iso-8859-3",
+	"ISO 2022 IR 109": "iso-8859-3",
+	"ISO_IR 110":      "iso-8859-4",
+	"ISO 2022 IR 110": "iso-8859-4",
+	"ISO_IR 126":      "iso-ir-126",
+	"ISO 2022 IR 126": "iso-ir-126",
+	"ISO_IR 127":      "iso-ir-127",
+	"ISO 2022 IR 127": "iso-ir-127",
+	"ISO_IR 138":      "iso-ir-138",
+	"ISO 2022 IR 138": "iso-ir-138",
+	"ISO_IR 144":      "iso-ir-144",
+	"ISO 2022 IR 144": "iso-ir-144",
+	"ISO_IR 148":      "iso-ir-148",
+	"ISO 2022 IR 148": "iso-ir-148",
+	"ISO 2022 IR 149": "euc-kr",
+	"ISO 2022 IR 159": "iso-2022-jp",
+	"ISO_IR 166":      "iso-ir-166",
+	"ISO 2022 IR 166": "iso-ir-166",
+	"ISO 2022 IR 87":  "iso-2022-jp",
+	"ISO 2022 IR 58":  "iso-ir-58",
+	"ISO_IR 192":      "utf8",
+	"GB18030":         "gb18030",
+	"GBK":             "gbk",
+}
+
+// ParseSpecificCharacterSet converts DICOM character encoding names, such as
+// "ISO-IR 100" to encoding.Decoder(s). It will return nil, nil for the default (7bit
+// ASCII) encoding. Cf. P3.2
+// D.6.2. http://dicom.nema.org/medical/dicom/2016d/output/chtml/part02/sect_D.6.2.html
+func ParseSpecificCharacterSet(encodingNames []string) (CodingSystem, error) {
+	var decoders []*encoding.Decoder
+	for _, name := range encodingNames {
+		var c *encoding.Decoder
+		if htmlName, ok := htmlEncodingNames[name]; !ok {
+			// TODO(saito) Support more encodings.
+			return CodingSystem{}, fmt.Errorf("ParseSpecificCharacterSet: Unknown character set '%s'. Assuming utf-8", name)
+		} else {
+			if htmlName != "" {
+				d, err := htmlindex.Get(htmlName)
+				if err != nil {
+					panic(fmt.Sprintf("Encoding name %s (for %s) not found", name, htmlName))
+				}
+				c = d.NewDecoder()
+			}
+		}
+		decoders = append(decoders, c)
+	}
+	if len(decoders) == 0 {
+		return CodingSystem{nil, nil, nil}, nil
+	}
+	if len(decoders) == 1 {
+		return CodingSystem{decoders[0], decoders[0], decoders[0]}, nil
+	}
+	if len(decoders) == 2 {
+		return CodingSystem{decoders[0], decoders[1], decoders[1]}, nil
+	}
+	return CodingSystem{decoders[0], decoders[1], decoders[2]}, nil
+}

--- a/pkg/dicomio/reader.go
+++ b/pkg/dicomio/reader.go
@@ -132,7 +132,6 @@ func internalReadString(data []byte, d *encoding.Decoder) (string, error) {
 	}
 	if d == nil {
 		// Assume ASCII
-		// TODO(saito) check that string is 7-bit clean.
 		return string(data), nil
 	}
 	bytes, err := d.Bytes(data)

--- a/pkg/dicomio/reader.go
+++ b/pkg/dicomio/reader.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+
+	"github.com/suyashkumar/dicom/pkg/charset"
+	"golang.org/x/text/encoding"
 )
 
 var (
@@ -25,7 +28,8 @@ type Reader interface {
 	ReadInt16() (int16, error)
 	// ReadInt32 reads a int32 from the underlying reader
 	ReadInt32() (int32, error)
-	// ReadString reads an n byte string from the underlying reader
+	// ReadString reads an n byte string from the underlying reader. Uses the charset.CodingSystem encoding.
+	// Decoders to read the string, if set.
 	ReadString(n uint32) (string, error)
 	// Skip skips the reader ahead by n bytes
 	Skip(n int64) error
@@ -42,6 +46,8 @@ type Reader interface {
 	SetTransferSyntax(bo binary.ByteOrder, implicit bool)
 	// IsImplicit returns if the currently set transfer syntax on this Reader is implicit or not.
 	IsImplicit() bool
+	// SetCodingSystem sets the charset.CodingSystem to be used when ReadString is called.
+	SetCodingSystem(cs charset.CodingSystem)
 }
 
 type reader struct {
@@ -51,6 +57,9 @@ type reader struct {
 	limit      int64
 	bytesRead  int64
 	limitStack []int64
+	// cs represents the CodingSystem to use when reading the string. If a particular encoding.
+	// Decoder within this CodingSystem is nil, assume ASCII
+	cs charset.CodingSystem
 }
 
 func NewReader(in io.Reader, bo binary.ByteOrder, limit int64) (Reader, error) {
@@ -116,11 +125,30 @@ func (r *reader) ReadInt32() (int32, error) {
 	err := binary.Read(r, r.bo, &out)
 	return out, err
 }
+
+func internalReadString(data []byte, d *encoding.Decoder) (string, error) {
+	if len(data) == 0 {
+		return "", nil
+	}
+	if d == nil {
+		// Assume ASCII
+		// TODO(saito) check that string is 7-bit clean.
+		return string(data), nil
+	}
+	bytes, err := d.Bytes(data)
+	if err != nil {
+		return "", err
+	}
+	return string(bytes), nil
+}
+
 func (r *reader) ReadString(n uint32) (string, error) {
 	data := make([]byte, n)
 	_, err := io.ReadFull(r, data)
-	// TODO: add support for different coding systems
-	return string(data), err
+	if err != nil {
+		return "", err
+	}
+	return internalReadString(data, r.cs.Ideographic)
 }
 func (r *reader) Skip(n int64) error {
 	if r.BytesLeftUntilLimit() < n {
@@ -166,3 +194,7 @@ func (r *reader) SetTransferSyntax(bo binary.ByteOrder, implicit bool) {
 }
 
 func (r *reader) IsImplicit() bool { return r.implicit }
+
+func (r *reader) SetCodingSystem(cs charset.CodingSystem) {
+	r.cs = cs
+}

--- a/transfer_syntax.go
+++ b/transfer_syntax.go
@@ -1,3 +1,0 @@
-package dicom
-
-const ()


### PR DESCRIPTION
This PR brings the rewritten 1.0 branch into parity with the existing code on master regarding character set support. It seems like character sets may need to be scoped to Sequences (see #88), which will be looked into shortly. More extensive testing will come in a follow up PR.