### PR TITLE
Force flag to override "Keyword 'DICM' not found in the header" (issue #59)

### DIFF
--- a/cmd/dicomutil/dicomutil.go
+++ b/cmd/dicomutil/dicomutil.go
@@ -51,7 +51,7 @@ func main() {
 		frameChannel := make(chan *frame.Frame, FrameBufferSize)
 		p, err := dicom.NewParserFromFile(path, frameChannel)
 		if err != nil {
-			log.Panic("error creating parser", err)
+			log.Panic("error creating parser: ", err)
 		}
 
 		// Go process frames published to frameChannel
@@ -62,7 +62,7 @@ func main() {
 		// Begin parsing
 		parsedData, err = p.Parse(dicom.ParseOptions{})
 		if err != nil {
-			log.Panic("error parsing", err)
+			log.Panic("error parsing: ", err)
 		}
 
 		// Wait for all frames to be streamed and processed
@@ -72,7 +72,7 @@ func main() {
 		// Non-streaming parsing:
 		p, err := dicom.NewParserFromFile(path, nil)
 		if err != nil {
-			log.Panic("error creating new parser", err)
+			log.Panic("error creating new parser: ", err)
 		}
 		parsedData, err = p.Parse(dicom.ParseOptions{DropPixelData: !*extractImages})
 		if parsedData == nil || err != nil {

--- a/parse.go
+++ b/parse.go
@@ -40,6 +40,7 @@ type parser struct {
 	// currentSequenceDataset is populated with Elements read so far in a SQ DICOM sequence (or is nil if not currently
 	// reading a sequence).
 	currentSequenceDataset *element.DataSet
+	force		bool
 }
 
 // NewParser initializes and returns a new Parser
@@ -467,8 +468,12 @@ func (p *parser) parseFileHeader() []*element.Element {
 
 	// check for magic word
 	if s := p.decoder.ReadString(4); s != "DICM" {
-		p.decoder.SetError(errors.New("Keyword 'DICM' not found in the header"))
-		return nil
+		if p.force {
+			dicomlog.Vprintf(1, "WARNING Keyword 'DICM' not found in the header. Force enabled, therefore continuing...")
+		} else {
+			p.decoder.SetError(errors.New("Keyword 'DICM' not found in the header. Set the 'force' parser flag to anyway"))
+			return nil
+		}
 	}
 
 	// (0002,0000) MetaElementGroupLength


### PR DESCRIPTION
@suyash I realized while I was writing this PR that the header (`func parseFileHeader`), is parsed inside of `NewParser`, which is where the override for the 'keyword not found' error goes. The original plan was to add a flag that the implementer could set after the creation of the parser and before the actual parsing of the file, but this is not an option because of when `parseFileHeader` is called

I see 3 options that could fix this. (1) we could move the parseFileHeader call out of `NewParser` and into `func (p *parser) Parse`. This would have the implication that the whole function would have to be parsed before the meta data could be read. (2) we could add the force flag as a function parameter in `NewParser` and subsequent parser-generating functions. This would have the implication of breaking backwards compatibility, however, since as far as I can tell golang doesn't have optional function parameters like python or other languages. (3) We could do a different version of option 2 and duplicate the NewParser functions and add the force flag as a parameter (something like `func NewParserFromFileForce(path string, frameChannel chan *frame.Frame) (Parser, error)` which would call `func NewParserForce(in io.Reader, bytesToRead int64, frameChannel chan *frame.Frame) (Parser, error)`) which would fix the backwards computability issue but add bloat code (Note: this is less convenient and the names have to be changed because it does not appear that golang [does not support](https://yourbasic.org/golang/overload-overwrite-optional-parameter/) function overloading. I went ahead and implemented option 3 in this PR, but I can go back and change it to whichever option you would like me to (or any other that I missed). Let me know what works best

I also added a commit that fixes the formatting for errors on the dicomutil tool. There was an issue where it would state it was panicking, then there was no space and it would print the error on the end of the last word in the panic message. I just added ": " to the end of the panic message and before the error is printed so they are distinct and more readable