### PR TITLE
Move element and dataset to pkg, add some docs.

### DIFF
--- a/cmd/dicomutil/main.go
+++ b/cmd/dicomutil/main.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 
 	"github.com/suyashkumar/dicom"
+	"github.com/suyashkumar/dicom/pkg/element"
 	"github.com/suyashkumar/dicom/pkg/frame"
 	"github.com/suyashkumar/dicom/pkg/tag"
 )
@@ -41,7 +42,7 @@ func main() {
 			return
 		}
 
-		var ds *dicom.Dataset
+		var ds *element.Dataset
 		if *extractImagesStream {
 			ds = parseWithStreaming(f, info.Size())
 		} else {
@@ -65,8 +66,8 @@ func main() {
 			log.Println(elem.Value)
 			// TODO: remove image icon hack after implementing flat iterator
 			if elem.Tag == tag.IconImageSequence {
-				for _, item := range elem.Value.GetValue().([]*dicom.SequenceItemValue) {
-					for _, subElem := range item.GetValue().([]*dicom.Element) {
+				for _, item := range elem.Value.GetValue().([]*element.SequenceItemValue) {
+					for _, subElem := range item.GetValue().([]*element.Element) {
 						if subElem.Tag == tag.PixelData {
 							writePixelDataElement(subElem, "icon")
 						}
@@ -78,7 +79,7 @@ func main() {
 	}
 }
 
-func parseWithStreaming(in io.Reader, size int64) *dicom.Dataset {
+func parseWithStreaming(in io.Reader, size int64) *element.Dataset {
 	fc := make(chan *frame.Frame, FrameBufferSize)
 	p, err := dicom.NewParser(in, size, fc)
 	if err != nil {
@@ -136,8 +137,8 @@ func generateImage(fr *frame.Frame, frameIndex int, wg *sync.WaitGroup) {
 	}
 }
 
-func writePixelDataElement(e *dicom.Element, id string) {
-	imageInfo := e.Value.GetValue().(dicom.PixelDataInfo)
+func writePixelDataElement(e *element.Element, id string) {
+	imageInfo := e.Value.GetValue().(element.PixelDataInfo)
 	for idx, f := range imageInfo.Frames {
 		generateImage(&f, idx, nil)
 	}

--- a/parse.go
+++ b/parse.go
@@ -1,3 +1,4 @@
+// Package dicom provides tools to read and work with DICOM binary files.
 package dicom
 
 import (
@@ -10,34 +11,45 @@ import (
 
 	"github.com/suyashkumar/dicom/pkg/charset"
 	"github.com/suyashkumar/dicom/pkg/dicomio"
+	"github.com/suyashkumar/dicom/pkg/element"
 	"github.com/suyashkumar/dicom/pkg/frame"
 	"github.com/suyashkumar/dicom/pkg/tag"
 	"github.com/suyashkumar/dicom/pkg/uid"
 )
 
 const (
-	MagicWord = "DICM"
+	magicWord = "DICM"
 )
 
 var (
-	ErrorMagicWord              = errors.New("error, DICM magic word not found in correct location")
+	// ErrorMagicWord indicates that the DICM magic word was not found at the correct location in the dicom.
+	ErrorMagicWord = errors.New("error, DICM magic word not found in correct location")
+	// ErrorMetaElementGroupLength indicates that the MetaElementGroupLength was not found where expected.
 	ErrorMetaElementGroupLength = errors.New("MetaElementGroupLength tag not found where expected")
 )
 
+// Parser represents a DICOM parser, initialized on a particular stream of DICOM bytes.
+// It is able to parse out DICOM elements from the raw binary data and return a Dataset of elements.
+// More information about these concepts can be found at http://dicom.nema.org/medical/dicom/current/output/chtml/part05/chapter_7.html.
+//
+// Check out the godoc for the element package to learn more about how these are represented in this library,
+// and tools for working with these constructs.
 type Parser interface {
-	// Parse DICOM data
-	Parse() (Dataset, error)
+	// Parse reads and parses DICOM binary data from this Parser and returns a Dataset of parsed Elements.
+	Parse() (element.Dataset, error)
 }
 
 type parser struct {
 	reader  dicomio.Reader
-	dataset Dataset
+	dataset element.Dataset
 	// file is optional, might be populated if reading from an underlying file
 	file         *os.File
-	frameChannel chan *frame.Frame
+	frameChannel chan<- *frame.Frame
 }
 
-func NewParser(in io.Reader, bytesToRead int64, frameChannel chan *frame.Frame) (Parser, error) {
+// NewParser creates a new Parser for the provided io.Reader and will read up to bytesToRead. frameChannel is optional,
+// and if supplied, image frame.Frames are sent to the channel as they are parsed--useful for streaming applications.
+func NewParser(in io.Reader, bytesToRead int64, frameChannel chan<- *frame.Frame) (Parser, error) {
 	reader, err := dicomio.NewReader(bufio.NewReader(in), binary.LittleEndian, bytesToRead)
 	if err != nil {
 		return nil, err
@@ -53,13 +65,13 @@ func NewParser(in io.Reader, bytesToRead int64, frameChannel chan *frame.Frame) 
 		return nil, err
 	}
 
-	p.dataset = Dataset{Elements: elems}
+	p.dataset = element.Dataset{Elements: elems}
 
 	return &p, nil
 }
 
 // readHeader reads the DICOM magic header and group two metadata elements.
-func (p *parser) readHeader() ([]*Element, error) {
+func (p *parser) readHeader() ([]*element.Element, error) {
 	// Must read as LittleEndian explicit VR
 	err := p.reader.Skip(128) // skip preamble
 	if err != nil {
@@ -68,7 +80,7 @@ func (p *parser) readHeader() ([]*Element, error) {
 	}
 
 	// Check DICOM magic word
-	if s, err := p.reader.ReadString(4); err != nil || s != MagicWord {
+	if s, err := p.reader.ReadString(4); err != nil || s != magicWord {
 		return nil, ErrorMagicWord
 	}
 
@@ -79,13 +91,13 @@ func (p *parser) readHeader() ([]*Element, error) {
 		return nil, err
 	}
 
-	if maybeMetaLen.Tag != tag.FileMetaInformationGroupLength || maybeMetaLen.Value.ValueType() != Ints {
+	if maybeMetaLen.Tag != tag.FileMetaInformationGroupLength || maybeMetaLen.Value.ValueType() != element.Ints {
 		return nil, ErrorMetaElementGroupLength
 	}
 
 	metaLen := maybeMetaLen.Value.GetValue().([]int)[0]
 
-	metaElems := []*Element{maybeMetaLen} // TODO: maybe set capacity to a reasonable initial size
+	metaElems := []*element.Element{maybeMetaLen} // TODO: maybe set capacity to a reasonable initial size
 
 	// Read the metadata elements
 	err = p.reader.PushLimit(int64(metaLen))
@@ -107,14 +119,14 @@ func (p *parser) readHeader() ([]*Element, error) {
 	return metaElems, nil
 }
 
-func (p *parser) Parse() (Dataset, error) {
+func (p *parser) Parse() (element.Dataset, error) {
 	// Determine and set the transfer syntax based on the metadata elements parsed so far.
 	ts, err := p.dataset.FindElementByTag(tag.TransferSyntaxUID)
 	if err != nil {
 		// proceed with a default?
 		log.Println("WARN: could not find transfer syntax uid in metadata, proceeding with little endian implicit")
 	}
-	bo, implicit, err := uid.ParseTransferSyntaxUID(MustGetString(ts.Value))
+	bo, implicit, err := uid.ParseTransferSyntaxUID(element.MustGetString(ts.Value))
 	if err != nil {
 		// proceed with a default?
 		log.Println("WARN: could not parse transfer syntax uid in metadata, proceeding with little endian implicit")
@@ -125,7 +137,7 @@ func (p *parser) Parse() (Dataset, error) {
 		elem, err := readElement(p.reader, &p.dataset, p.frameChannel)
 		if err != nil {
 			// TODO: tolerate some kinds of errors and continue parsing
-			return Dataset{}, err
+			return element.Dataset{}, err
 		}
 
 		log.Println("Read tag: ", elem.Tag)
@@ -133,7 +145,7 @@ func (p *parser) Parse() (Dataset, error) {
 		// TODO: add dicom options to only keep track of certain tags
 
 		if elem.Tag == tag.SpecificCharacterSet {
-			encodingNames := MustGetStrings(elem.Value)
+			encodingNames := element.MustGetStrings(elem.Value)
 			cs, err := charset.ParseSpecificCharacterSet(encodingNames)
 			if err != nil {
 				// unable to parse character set, hard error

--- a/parse.go
+++ b/parse.go
@@ -1,4 +1,8 @@
 // Package dicom provides tools to read and work with DICOM binary files.
+//
+// The Parser is able to parse DICOM data into
+// an element.Dataset, which is a collection of element.Element(s) that represent information inside the DICOM. See the
+// godoc for the element package to learn more about how to work with element.Element entities.
 package dicom
 
 import (

--- a/pkg/element/dataset.go
+++ b/pkg/element/dataset.go
@@ -1,4 +1,4 @@
-package dicom
+package element
 
 import (
 	"errors"

--- a/pkg/element/element.go
+++ b/pkg/element/element.go
@@ -1,4 +1,4 @@
-package dicom
+package element
 
 import (
 	"fmt"
@@ -51,65 +51,65 @@ const (
 
 // Begin definitions of Values:
 
-// BytesValue represents a value of []byte.
+// BytesValue represents a Value of []byte.
 type BytesValue struct {
-	value []byte
+	Value []byte
 }
 
 func (b *BytesValue) isElementValue()       {}
 func (b *BytesValue) ValueType() ValueType  { return Bytes }
-func (b *BytesValue) GetValue() interface{} { return b.value }
+func (b *BytesValue) GetValue() interface{} { return b.Value }
 func (b *BytesValue) String() string {
-	return fmt.Sprintf("%v", b.value)
+	return fmt.Sprintf("%v", b.Value)
 }
 
-// StringsValue represents a value of []string.
+// StringsValue represents a Value of []string.
 type StringsValue struct {
-	value []string
+	Value []string
 }
 
 func (s *StringsValue) isElementValue()       {}
 func (s *StringsValue) ValueType() ValueType  { return Strings }
-func (s *StringsValue) GetValue() interface{} { return s.value }
+func (s *StringsValue) GetValue() interface{} { return s.Value }
 func (s *StringsValue) String() string {
-	return fmt.Sprintf("%v", s.value)
+	return fmt.Sprintf("%v", s.Value)
 }
 
-// IntsValue represents a value of []int.
+// IntsValue represents a Value of []int.
 type IntsValue struct {
-	value []int
+	Value []int
 }
 
 func (s *IntsValue) isElementValue()       {}
 func (s *IntsValue) ValueType() ValueType  { return Ints }
-func (s *IntsValue) GetValue() interface{} { return s.value }
+func (s *IntsValue) GetValue() interface{} { return s.Value }
 func (s *IntsValue) String() string {
-	return fmt.Sprintf("%v", s.value)
+	return fmt.Sprintf("%v", s.Value)
 }
 
 type SequenceItemValue struct {
-	elements []*Element
+	Elements []*Element
 }
 
 func (s *SequenceItemValue) isElementValue()       {}
 func (s *SequenceItemValue) ValueType() ValueType  { return SequenceItem }
-func (s *SequenceItemValue) GetValue() interface{} { return s.elements }
+func (s *SequenceItemValue) GetValue() interface{} { return s.Elements }
 func (s *SequenceItemValue) String() string {
 	// TODO: consider adding more sophisticated formatting
-	return fmt.Sprintf("%+v", s.elements)
+	return fmt.Sprintf("%+v", s.Elements)
 }
 
 // SequencesValue represents a set of items in a DICOM sequence.
 type SequencesValue struct {
-	value []*SequenceItemValue
+	Value []*SequenceItemValue
 }
 
 func (s *SequencesValue) isElementValue()       {}
 func (s *SequencesValue) ValueType() ValueType  { return Sequences }
-func (s *SequencesValue) GetValue() interface{} { return s.value }
+func (s *SequencesValue) GetValue() interface{} { return s.Value }
 func (s *SequencesValue) String() string {
 	// TODO: consider adding more sophisticated formatting
-	return fmt.Sprintf("%+v", s.value)
+	return fmt.Sprintf("%+v", s.Value)
 }
 
 type PixelDataInfo struct {


### PR DESCRIPTION
I'm not sure exactly how I feel about this, but this moves `Element` and `Dataset` to a pkg. This is useful to avoid circular dependencies in the future, and have utilities work with those entities, and cleans up the top level dicom namespace a lot.

This comes at the cost of some stutter (e.g. `element.Element`) and the loss of some nice naming (e.g. `dicom.Element` was nice to have). 

We can always revisit this before launching the rewritten code.