### PR TITLE
Implement initial FlatIterator for a Dataset

### DIFF
--- a/dataset.go
+++ b/dataset.go
@@ -22,3 +22,38 @@ func (d *Dataset) FindElementByTag(tag tag.Tag) (*Element, error) {
 	}
 	return nil, ErrorElementNotFound
 }
+
+// FindElementByTagNested searches through the dataset and returns a pointer to the matching element.
+// This call searches through a flat representation of the dataset, including within sequences.
+func (d *Dataset) FindElementByTagNested(tag tag.Tag) (*Element, error) {
+	for e := range d.FlatIterator() {
+		if e.Tag == tag {
+			return e, nil
+		}
+	}
+	return nil, ErrorElementNotFound
+}
+
+// FlatIterator returns a channel upon which every element in this Dataset will be sent,
+// including elements nested inside sequences.
+// Note that the sequence element itself is sent on the channel in addition to the child elements in the sequence.
+// TODO(suyashkumar): decide if the sequence element itself should be sent or not
+func (d *Dataset) FlatIterator() <-chan *Element {
+	elemChan := make(chan *Element)
+	go func() {
+		flatElementsIterator(d.Elements, elemChan)
+		close(elemChan)
+	}()
+	return elemChan
+}
+
+func flatElementsIterator(elems []*Element, elemChan chan<- *Element) {
+	for _, elem := range elems {
+		if elem.Value.ValueType() == Sequences {
+			for _, seqItem := range elem.Value.GetValue().([]*SequenceItemValue) {
+				flatElementsIterator(seqItem.elements, elemChan)
+			}
+		}
+		elemChan <- elem
+	}
+}

--- a/dataset_test.go
+++ b/dataset_test.go
@@ -1,0 +1,99 @@
+package dicom
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/suyashkumar/dicom/pkg/tag"
+)
+
+func makeSequenceElement(tg tag.Tag, items [][]*Element) *Element {
+	sequenceItems := make([]*SequenceItemValue, 0, len(items))
+	for _, item := range items {
+		sequenceItems = append(sequenceItems, &SequenceItemValue{elements: item})
+	}
+
+	return &Element{
+		Tag:                 tg,
+		ValueRepresentation: tag.VRSequence,
+		Value: &SequencesValue{
+			value: sequenceItems,
+		},
+	}
+}
+
+func TestDataset_FindElementByTag(t *testing.T) {
+	data := Dataset{
+		Elements: []*Element{
+			{
+				Tag:                 tag.Rows,
+				ValueRepresentation: tag.VRInt32List,
+				Value: &IntsValue{
+					value: []int{100},
+				},
+			},
+			{
+				Tag:                 tag.Columns,
+				ValueRepresentation: tag.VRInt32List,
+				Value: &IntsValue{
+					value: []int{200},
+				},
+			},
+		},
+	}
+
+	elem, err := data.FindElementByTag(tag.Rows)
+	if err != nil {
+		t.Errorf("FindElementByTag(%v): unexpected err: %v", tag.Rows, err)
+	}
+
+	if rows := MustGetInts(elem.Value)[0]; rows != 100 {
+		t.Errorf("FindElementByTag(%v): want: %v, got: %v", tag.Rows, 100, rows)
+	}
+}
+
+func ExampleDataset_FlatIterator() {
+	nestedData := [][]*Element{
+		[]*Element{
+			{
+				Tag:                 tag.PatientName,
+				ValueRepresentation: tag.VRString,
+				Value: &StringsValue{
+					value: []string{"Bob"},
+				},
+			},
+		},
+	}
+
+	data := Dataset{
+		Elements: []*Element{
+			{
+				Tag:                 tag.Rows,
+				ValueRepresentation: tag.VRInt32List,
+				Value: &IntsValue{
+					value: []int{100},
+				},
+			},
+			{
+				Tag:                 tag.Columns,
+				ValueRepresentation: tag.VRInt32List,
+				Value: &IntsValue{
+					value: []int{200},
+				},
+			},
+			makeSequenceElement(tag.AddOtherSequence, nestedData),
+		},
+	}
+
+	for elem := range data.FlatIterator() {
+		fmt.Println(elem.Tag)
+	}
+
+	// Note the output below includes all three leaf elements __as well as__ the sequence element's tag
+
+	// Unordered output:
+	// (0028,0010)
+	// (0028,0011)
+	// (0010,0010)
+	// (0046,0102)
+}


### PR DESCRIPTION
This change implements a simple FlatIterator for a dataset which sends all elements in a Dataset to a channel, including elements nested inside Sequences. This also implements initial sanity tests and testable examples, along with a helper `FindElementByTagNested` function. 