### PR TITLE
Implement initial JSON Marshal support for Dataset and Element

### DIFF
--- a/dataset.go
+++ b/dataset.go
@@ -9,7 +9,7 @@ import (
 var ErrorElementNotFound = errors.New("element not found")
 
 type Dataset struct {
-	Elements []*Element
+	Elements []*Element `json:"elements"`
 }
 
 // FindElementByTag searches through the dataset and returns a pointer to the matching element.

--- a/element.go
+++ b/element.go
@@ -1,27 +1,19 @@
 package dicom
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/suyashkumar/dicom/pkg/frame"
 	"github.com/suyashkumar/dicom/pkg/tag"
 )
 
-type RawElement struct {
-	Tag                    tag.Tag
-	ValueRepresentation    tag.VRKind
-	RawValueRepresentation string
-	ValueLength            uint32
-	UndefinedLength        bool
-	Value                  []byte
-}
-
 type Element struct {
-	Tag                    tag.Tag
-	ValueRepresentation    tag.VRKind
-	RawValueRepresentation string
-	ValueLength            uint32
-	Value                  Value
+	Tag                    tag.Tag    `json:"tag"`
+	ValueRepresentation    tag.VRKind `json:"VR"`
+	RawValueRepresentation string     `json:"rawVR"`
+	ValueLength            uint32     `json:"valueLength"`
+	Value                  Value      `json:"value"`
 }
 
 func (e *Element) String() string {
@@ -35,6 +27,7 @@ type Value interface {
 	ValueType() ValueType
 	GetValue() interface{} // TODO: rename to Get to read cleaner
 	String() string
+	MarshalJSON() ([]byte, error)
 }
 
 type ValueType int
@@ -53,7 +46,7 @@ const (
 
 // BytesValue represents a value of []byte.
 type BytesValue struct {
-	value []byte
+	value []byte `json:"value"`
 }
 
 func (b *BytesValue) isElementValue()       {}
@@ -62,10 +55,13 @@ func (b *BytesValue) GetValue() interface{} { return b.value }
 func (b *BytesValue) String() string {
 	return fmt.Sprintf("%v", b.value)
 }
+func (b *BytesValue) MarshalJSON() ([]byte, error) {
+	return json.Marshal(b.value)
+}
 
 // StringsValue represents a value of []string.
 type StringsValue struct {
-	value []string
+	value []string `json:"value"`
 }
 
 func (s *StringsValue) isElementValue()       {}
@@ -74,10 +70,13 @@ func (s *StringsValue) GetValue() interface{} { return s.value }
 func (s *StringsValue) String() string {
 	return fmt.Sprintf("%v", s.value)
 }
+func (s *StringsValue) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.value)
+}
 
 // IntsValue represents a value of []int.
 type IntsValue struct {
-	value []int
+	value []int `json:"value"`
 }
 
 func (s *IntsValue) isElementValue()       {}
@@ -86,9 +85,12 @@ func (s *IntsValue) GetValue() interface{} { return s.value }
 func (s *IntsValue) String() string {
 	return fmt.Sprintf("%v", s.value)
 }
+func (s *IntsValue) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.value)
+}
 
 type SequenceItemValue struct {
-	elements []*Element
+	elements []*Element `json:"elements"`
 }
 
 func (s *SequenceItemValue) isElementValue()       {}
@@ -98,10 +100,13 @@ func (s *SequenceItemValue) String() string {
 	// TODO: consider adding more sophisticated formatting
 	return fmt.Sprintf("%+v", s.elements)
 }
+func (s *SequenceItemValue) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.elements)
+}
 
 // SequencesValue represents a set of items in a DICOM sequence.
 type SequencesValue struct {
-	value []*SequenceItemValue
+	value []*SequenceItemValue `json:"sequenceItems"`
 }
 
 func (s *SequencesValue) isElementValue()       {}
@@ -111,11 +116,14 @@ func (s *SequencesValue) String() string {
 	// TODO: consider adding more sophisticated formatting
 	return fmt.Sprintf("%+v", s.value)
 }
+func (s *SequencesValue) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.value)
+}
 
 type PixelDataInfo struct {
 	Frames         []frame.Frame // Frames
-	IsEncapsulated bool
-	Offsets        []uint32 // BasicOffsetTable
+	IsEncapsulated bool          `json:"isEncapsulated"`
+	Offsets        []uint32      // BasicOffsetTable
 }
 
 // PixelDataValue represents DICOM PixelData
@@ -129,6 +137,9 @@ func (e *PixelDataValue) GetValue() interface{} { return e.PixelDataInfo }
 func (e *PixelDataValue) String() string {
 	// TODO: consider adding more sophisticated formatting
 	return ""
+}
+func (s *PixelDataValue) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.PixelDataInfo)
 }
 
 func MustGetInt(v Value) int {

--- a/element_test.go
+++ b/element_test.go
@@ -1,0 +1,33 @@
+package dicom
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/suyashkumar/dicom/pkg/tag"
+)
+
+func TestElement_MarshalJSON_NestedElements(t *testing.T) {
+	nestedData := [][]*Element{
+		{
+			{
+				Tag:                 tag.PatientName,
+				ValueRepresentation: tag.VRString,
+				Value: &StringsValue{
+					value: []string{"Bob"},
+				},
+			},
+		},
+	}
+	seqElement := makeSequenceElement(tag.AddOtherSequence, nestedData)
+
+	want := `{"tag":{"Group":70,"Element":258},"VR":9,"rawVR":"","valueLength":0,"value":[[{"tag":{"Group":16,"Element":16},"VR":2,"rawVR":"","valueLength":0,"value":["Bob"]}]]}`
+
+	j, err := json.Marshal(seqElement)
+	if err != nil {
+		t.Errorf("unexpected error marshaling json: %v", err)
+	}
+	if string(j) != want {
+		t.Errorf("json.Marshal(%v) produced incorrect output. want: %s, got:%s", seqElement, want, string(j))
+	}
+}

--- a/parse.go
+++ b/parse.go
@@ -101,7 +101,7 @@ func (p *parser) readHeader() ([]*Element, error) {
 
 			return nil, err
 		}
-		log.Printf("Metadata Element: %s\n", elem)
+		// log.Printf("Metadata Element: %s\n", elem)
 		metaElems = append(metaElems, elem)
 	}
 	return metaElems, nil
@@ -128,7 +128,7 @@ func (p *parser) Parse() (Dataset, error) {
 			return Dataset{}, err
 		}
 
-		log.Println("Read tag: ", elem.Tag)
+		// log.Println("Read tag: ", elem.Tag)
 
 		// TODO: add dicom options to only keep track of certain tags
 

--- a/read.go
+++ b/read.go
@@ -306,8 +306,6 @@ func readSequenceItem(r dicomio.Reader, t tag.Tag, vr string, vl uint32) (Value,
 	// TODO: deduplicate with sequenceItem above
 	var seqElements Dataset
 
-	log.Println("readSequenceItem TOP LOOP")
-
 	if vl == tag.VLUndefinedLength {
 		for {
 			subElem, err := readElement(r, &seqElements, nil)
@@ -317,7 +315,7 @@ func readSequenceItem(r dicomio.Reader, t tag.Tag, vr string, vl uint32) (Value,
 			if subElem.Tag == tag.ItemDelimitationItem {
 				break
 			}
-			log.Println("readSequenceItem: tag: ", subElem.Tag)
+			// log.Println("readSequenceItem: tag: ", subElem.Tag)
 
 			sequenceItem.elements = append(sequenceItem.elements, subElem)
 			seqElements.Elements = append(seqElements.Elements, subElem)
@@ -333,7 +331,7 @@ func readSequenceItem(r dicomio.Reader, t tag.Tag, vr string, vl uint32) (Value,
 			if err != nil {
 				return nil, err
 			}
-			log.Println("readSequenceItem: tag: ", subElem.Tag)
+			// log.Println("readSequenceItem: tag: ", subElem.Tag)
 
 			sequenceItem.elements = append(sequenceItem.elements, subElem)
 			seqElements.Elements = append(seqElements.Elements, subElem)
@@ -448,7 +446,7 @@ func readElement(r dicomio.Reader, d *Dataset, fc chan<- *frame.Frame) (*Element
 	if err != nil {
 		return nil, err
 	}
-	log.Println("readElement: readTag: ", t)
+	// log.Println("readElement: readTag: ", t)
 
 	vr, err := readVR(r, r.IsImplicit(), *t)
 	if err != nil {
@@ -460,7 +458,7 @@ func readElement(r dicomio.Reader, d *Dataset, fc chan<- *frame.Frame) (*Element
 		return nil, err
 	}
 
-	log.Println("readElement: vr, vl", vr, vl)
+	// log.Println("readElement: vr, vl", vr, vl)
 
 	val, err := readValue(r, *t, vr, vl, r.IsImplicit(), d, fc)
 	if err != nil {
@@ -468,7 +466,7 @@ func readElement(r dicomio.Reader, d *Dataset, fc chan<- *frame.Frame) (*Element
 		return nil, err
 	}
 
-	return &Element{Tag: *t, ValueRepresentation: tag.GetVRKind(*t, vr), ValueLength: vl, Value: val}, nil
+	return &Element{Tag: *t, ValueRepresentation: tag.GetVRKind(*t, vr), RawValueRepresentation: vr, ValueLength: vl, Value: val}, nil
 
 }
 


### PR DESCRIPTION
🎉 This implements initial JSON Marshal support for `Dataset` and `Element`. This also adds in a `--json` option to `dicomutil` to print a JSON representation of the parsed dataset to stdout. 

Probably there will be a __lot more cleanup and finetuning to do__ (e.g. better serialization of tag), but this is a start. Of course, it would also be good to implement unmarshal support in the future too. 

This addresses #13, but is on the rewrite branch (not main yet).

Here's what a random element looks like JSON serialized:
```json
    {
      "tag": {
        "Group": 2,
        "Element": 0
      },
      "VR": 4,
      "rawVR": "UL",
      "valueLength": 4,
      "value": [
        198
      ]
    }
```

Of course, nested elements in DICOM sequences are supported too.