### PR TITLE
[Rewrite] Implement clean string serialization for a Dataset

### DIFF
--- a/cmd/dicomutil/main.go
+++ b/cmd/dicomutil/main.go
@@ -58,14 +58,18 @@ func main() {
 		}
 
 		if *printJSON {
+			log.Println("Printing DICOM dataset serialized as JSON to stdout")
 			j, err := json.MarshalIndent(ds, "", "  ")
 			if err != nil {
 				panic(err)
 			}
+
 			fmt.Println(string(j))
 		} else {
+			log.Println("Printing DICOM dataset parsed elements to stdout:")
 			fmt.Print(ds)
 
+			// In non-streaming frame mode, we need to find all PixelData elements and generate images.
 			for _, elem := range ds.Elements {
 				if elem.Tag == tag.PixelData && !*extractImagesStream {
 					writePixelDataElement(elem, "")

--- a/cmd/dicomutil/main.go
+++ b/cmd/dicomutil/main.go
@@ -64,14 +64,12 @@ func main() {
 			}
 			fmt.Println(string(j))
 		} else {
+			fmt.Print(ds)
 
 			for _, elem := range ds.Elements {
 				if elem.Tag == tag.PixelData && !*extractImagesStream {
 					writePixelDataElement(elem, "")
 				}
-				log.Println(elem.Tag)
-				log.Println(elem.ValueLength)
-				log.Println(elem.Value)
 				// TODO: remove image icon hack after implementing flat iterator
 				if elem.Tag == tag.IconImageSequence {
 					for _, item := range elem.Value.GetValue().([]*dicom.SequenceItemValue) {

--- a/dataset.go
+++ b/dataset.go
@@ -65,10 +65,17 @@ func flatElementsIterator(elems []*Element, elemChan chan<- *Element) {
 // String returns a representation of this dataset as a string
 func (d *Dataset) String() string {
 	var b strings.Builder
+	b.Grow(len(d.Elements) * 100) // Underestimate of the size of the final string in an attempt to limit buffer copying
 	for elem := range d.flatIteratorWithLevel() {
 		tabs := buildTabs(elem.l)
+		var tagName string
+		if tagInfo, err := tag.Find(elem.e.Tag); err == nil {
+			tagName = tagInfo.Name
+		}
+
 		b.WriteString(fmt.Sprintf("%s[\n", tabs))
 		b.WriteString(fmt.Sprintf("%s  Tag: %s\n", tabs, elem.e.Tag))
+		b.WriteString(fmt.Sprintf("%s  Tag Name: %s\n", tabs, tagName))
 		b.WriteString(fmt.Sprintf("%s  VR: %s\n", tabs, elem.e.ValueRepresentation))
 		b.WriteString(fmt.Sprintf("%s  VR Raw: %s\n", tabs, elem.e.RawValueRepresentation))
 		b.WriteString(fmt.Sprintf("%s  VL: %d\n", tabs, elem.e.ValueLength))

--- a/dataset_test.go
+++ b/dataset_test.go
@@ -54,7 +54,7 @@ func TestDataset_FindElementByTag(t *testing.T) {
 
 func ExampleDataset_FlatIterator() {
 	nestedData := [][]*Element{
-		[]*Element{
+		{
 			{
 				Tag:                 tag.PatientName,
 				ValueRepresentation: tag.VRString,

--- a/element.go
+++ b/element.go
@@ -17,7 +17,13 @@ type Element struct {
 }
 
 func (e *Element) String() string {
-	return fmt.Sprintf("[\n  Tag: %s\n  VR: %s\n  VR Raw: %s\n  VL: %d\n  Value: %s\n]\n\n", e.Tag.String(),
+	var tagName string
+	if tagInfo, err := tag.Find(e.Tag); err == nil {
+		tagName = tagInfo.Name
+	}
+	return fmt.Sprintf("[\n  Tag: %s\n  Tag Name: %s\n  VR: %s\n  VR Raw: %s\n  VL: %d\n  Value: %s\n]\n\n",
+		e.Tag.String(),
+		tagName,
 		e.ValueRepresentation.String(),
 		e.RawValueRepresentation,
 		e.ValueLength,

--- a/element.go
+++ b/element.go
@@ -17,7 +17,11 @@ type Element struct {
 }
 
 func (e *Element) String() string {
-	return fmt.Sprintf("Tag:%s\nVR:%s\nValue:%s\n\n", e.Tag.String(), e.ValueRepresentation.String(), e.Value.String())
+	return fmt.Sprintf("[\n  Tag: %s\n  VR: %s\n  VR Raw: %s\n  VL: %d\n  Value: %s\n]\n\n", e.Tag.String(),
+		e.ValueRepresentation.String(),
+		e.RawValueRepresentation,
+		e.ValueLength,
+		e.Value.String())
 }
 
 type Value interface {

--- a/element_test.go
+++ b/element_test.go
@@ -43,6 +43,7 @@ func TestElement_String(t *testing.T) {
 	}
 	want := "[\n" +
 		"  Tag: (0028,0010)\n" +
+		"  Tag Name: Rows\n" +
 		"  VR: VRInt32List\n" +
 		"  VR Raw: US\n" +
 		"  VL: 0\n" +

--- a/element_test.go
+++ b/element_test.go
@@ -31,3 +31,26 @@ func TestElement_MarshalJSON_NestedElements(t *testing.T) {
 		t.Errorf("json.Marshal(%v) produced incorrect output. want: %s, got:%s", seqElement, want, string(j))
 	}
 }
+
+func TestElement_String(t *testing.T) {
+	e := &Element{
+		Tag:                    tag.Rows,
+		ValueRepresentation:    tag.VRInt32List,
+		RawValueRepresentation: "US",
+		Value: &IntsValue{
+			value: []int{100},
+		},
+	}
+	want := "[\n" +
+		"  Tag: (0028,0010)\n" +
+		"  VR: VRInt32List\n" +
+		"  VR Raw: US\n" +
+		"  VL: 0\n" +
+		"  Value: [100]\n" +
+		"]\n\n"
+	got := e.String()
+	if want != got {
+		t.Errorf("String(%v) unexpected diff. want:\n%s got:\n%s ", e, want, got)
+	}
+
+}


### PR DESCRIPTION
This implements a clean string serialization for an Element and Dataset. Note JSON serialization was added in #98, so this is in addition to that.

It looks something like this:
```
[
  Tag: (0054,0081)
  Tag Name: NumberOfSlices
  VR: VRUInt16List
  VR Raw: US
  VL: 2
  Value: &{[111]}
]
```

When a `Dataset` is serialized to a string, children elements in a Sequence are indented, like so:
```
[
  Tag: (0012,0064)
  Tag Name: DeidentificationMethodCodeSequence
  VR: VRSequence
  VR Raw: SQ
  VL: 4294967295
  Value: &{[824634238848 824634239072 824634239296 824634239552 824634239776 824634240000 824634240224 824634240448]}
]

    [
      Tag: (0008,0100)
      Tag Name: CodeValue
      VR: VRStringList
      VR Raw: SH
      VL: 6
      Value: &{[%!d(string=113100)]}
    ]

    [
      Tag: (0008,0102)
      Tag Name: CodingSchemeDesignator
      VR: VRStringList
      VR Raw: SH
      VL: 4
      Value: &{[%!d(string=DCM)]}
    ]
...
```