### PR TITLE
Add missing opts parameter to downstream call to write.Dataset

### DIFF
--- a/write/writer.go
+++ b/write/writer.go
@@ -447,7 +447,7 @@ func DataSetToFile(path string, ds *element.DataSet, opts ...Option) error {
 	if err != nil {
 		return err
 	}
-	if err := DataSet(out, ds); err != nil {
+	if err := DataSet(out, ds, opts...); err != nil {
 		out.Close()
 		return err
 	}


### PR DESCRIPTION
Function `write.DataSetToFile` does not pass `opts` argument further down the line.  This PR fixes this.