### PR TITLE
Reduce API surface by making the various value implementations private

### DIFF
--- a/dataset_test.go
+++ b/dataset_test.go
@@ -16,7 +16,7 @@ func makeSequenceElement(tg tag.Tag, items [][]*Element) *Element {
 	return &Element{
 		Tag:                 tg,
 		ValueRepresentation: tag.VRSequence,
-		Value: &SequencesValue{
+		Value: &sequencesValue{
 			value: sequenceItems,
 		},
 	}
@@ -28,14 +28,14 @@ func TestDataset_FindElementByTag(t *testing.T) {
 			{
 				Tag:                 tag.Rows,
 				ValueRepresentation: tag.VRInt32List,
-				Value: &IntsValue{
+				Value: &intsValue{
 					value: []int{100},
 				},
 			},
 			{
 				Tag:                 tag.Columns,
 				ValueRepresentation: tag.VRInt32List,
-				Value: &IntsValue{
+				Value: &intsValue{
 					value: []int{200},
 				},
 			},
@@ -58,7 +58,7 @@ func ExampleDataset_FlatIterator() {
 			{
 				Tag:                 tag.PatientName,
 				ValueRepresentation: tag.VRString,
-				Value: &StringsValue{
+				Value: &stringsValue{
 					value: []string{"Bob"},
 				},
 			},
@@ -70,14 +70,14 @@ func ExampleDataset_FlatIterator() {
 			{
 				Tag:                 tag.Rows,
 				ValueRepresentation: tag.VRInt32List,
-				Value: &IntsValue{
+				Value: &intsValue{
 					value: []int{100},
 				},
 			},
 			{
 				Tag:                 tag.Columns,
 				ValueRepresentation: tag.VRInt32List,
-				Value: &IntsValue{
+				Value: &intsValue{
 					value: []int{200},
 				},
 			},

--- a/element.go
+++ b/element.go
@@ -182,7 +182,7 @@ func MustGetBytes(v Value) []byte {
 
 func MustGetPixelDataInfo(v Value) PixelDataInfo {
 	if v.ValueType() != PixelData {
-		log.Panicf("MustGetBytes expected ValueType of PixelData, got: %v", v.ValueType())
+		log.Panicf("MustGetPixelDataInfo expected ValueType of PixelData, got: %v", v.ValueType())
 	}
 	return v.GetValue().(PixelDataInfo)
 }

--- a/element_test.go
+++ b/element_test.go
@@ -13,7 +13,7 @@ func TestElement_MarshalJSON_NestedElements(t *testing.T) {
 			{
 				Tag:                 tag.PatientName,
 				ValueRepresentation: tag.VRString,
-				Value: &StringsValue{
+				Value: &stringsValue{
 					value: []string{"Bob"},
 				},
 			},
@@ -37,7 +37,7 @@ func TestElement_String(t *testing.T) {
 		Tag:                    tag.Rows,
 		ValueRepresentation:    tag.VRInt32List,
 		RawValueRepresentation: "US",
-		Value: &IntsValue{
+		Value: &intsValue{
 			value: []int{100},
 		},
 	}

--- a/parse.go
+++ b/parse.go
@@ -114,7 +114,7 @@ func (p *parser) Parse() (Dataset, error) {
 		// proceed with a default?
 		log.Println("WARN: could not find transfer syntax uid in metadata, proceeding with little endian implicit")
 	}
-	bo, implicit, err := uid.ParseTransferSyntaxUID(MustGetString(ts.Value))
+	bo, implicit, err := uid.ParseTransferSyntaxUID(MustGetStrings(ts.Value)[0])
 	if err != nil {
 		// proceed with a default?
 		log.Println("WARN: could not parse transfer syntax uid in metadata, proceeding with little endian implicit")


### PR DESCRIPTION
Not sure if I prefer this or just moving all the these Value implementations to a pkg, but let's try this out for now. 