### PR TITLE
Fix VR=OB byte reads

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -131,8 +131,6 @@ func (p *parser) Parse() (Dataset, error) {
 			return Dataset{}, err
 		}
 
-		// log.Println("Read tag: ", elem.Tag)
-
 		// TODO: add dicom options to only keep track of certain tags
 
 		if elem.Tag == tag.SpecificCharacterSet {

--- a/read.go
+++ b/read.go
@@ -347,7 +347,7 @@ func readBytes(r dicomio.Reader, t tag.Tag, vr string, vl uint32) (Value, error)
 	// TODO: add special handling of PixelData
 	if vr == "OB" {
 		data := make([]byte, vl)
-		_, err := r.Read(data)
+		_, err := io.ReadFull(r, data)
 		return &bytesValue{value: data}, err
 	} else if vr == "OW" {
 		// OW -> stream of 16 bit words


### PR DESCRIPTION
This fixes #109 by ensuring the full byte array is read for VR=OB. 

The dicoms provided in #109 will be added to a test set in an upcoming PR around a larger integration testing framework. 