### PR TITLE
Update Parser API

### DIFF
--- a/cmd/dicomutil/main.go
+++ b/cmd/dicomutil/main.go
@@ -46,11 +46,7 @@ func main() {
 		if *extractImagesStream {
 			ds = parseWithStreaming(f, info.Size())
 		} else {
-			p, err := dicom.NewParser(f, info.Size(), nil)
-			if err != nil {
-				log.Fatalf("error creating parser: %v", err)
-			}
-			data, err := p.Parse()
+			data, err := dicom.Parse(f, info.Size(), nil)
 			if err != nil {
 				log.Fatalf("error parsing data: %v", err)
 			}
@@ -93,17 +89,13 @@ func main() {
 
 func parseWithStreaming(in io.Reader, size int64) *dicom.Dataset {
 	fc := make(chan *frame.Frame, FrameBufferSize)
-	p, err := dicom.NewParser(in, size, fc)
-	if err != nil {
-		log.Fatalf("error creating parser: %v", err)
-	}
 
 	// Go routine to process frames as they are sent to frameChannel
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go writeStreamingFrames(fc, &wg)
 
-	ds, err := p.Parse()
+	ds, err := dicom.Parse(in, size, fc)
 	if err != nil {
 		log.Fatalf("error parsing: %v", err)
 	}

--- a/parse.go
+++ b/parse.go
@@ -22,14 +22,35 @@ const (
 var (
 	ErrorMagicWord              = errors.New("error, DICM magic word not found in correct location")
 	ErrorMetaElementGroupLength = errors.New("MetaElementGroupLength tag not found where expected")
+	ErrorEndOfDICOM             = errors.New("this indicates to the caller of Next() that the DICOM has been fully parsed.")
 )
 
-type Parser interface {
-	// Parse DICOM data into a Dataset
-	Parse() (Dataset, error)
+// Parse parses the entire DICOM at the input io.Reader into a Dataset of DICOM Elements. Use this if you are
+// looking to parse the DICOM all at once, instead of element-by-element.
+func Parse(in io.Reader, bytesToRead int64, frameChan chan *frame.Frame) (Dataset, error) {
+	p, err := NewParser(in, bytesToRead, frameChan)
+	if err != nil {
+		return Dataset{}, err
+	}
+
+	for !p.reader.IsLimitExhausted() {
+		_, err := p.Next()
+		if err != nil {
+			return p.dataset, err
+		}
+	}
+
+	// Close the frameChannel if needed
+	if p.frameChannel != nil {
+		close(p.frameChannel)
+	}
+	return p.dataset, nil
 }
 
-type parser struct {
+// Parser is a struct that allows a user to parse Elements from a DICOM element-by-element using Next(), which may be
+// useful for some streaming processing applications. If you instead just want to parse the whole input DICOM at once,
+// just use the dicom.Parse(...) method.
+type Parser struct {
 	reader  dicomio.Reader
 	dataset Dataset
 	// file is optional, might be populated if reading from an underlying file
@@ -37,16 +58,18 @@ type parser struct {
 	frameChannel chan *frame.Frame
 }
 
-// NewParser returns a new Parser that points to the provided io.Reader, with bytesToRead bytes left to read. The
+// NewParser returns a new Parser that points to the provided io.Reader, with bytesToRead bytes left to read. NewParser
+// will read the DICOM header and metadata as part of initialization.
+//
 // frameChannel is an optional channel (can be nil) upon which DICOM image frames will be sent as they are parsed (if
 // provided).
-func NewParser(in io.Reader, bytesToRead int64, frameChannel chan *frame.Frame) (Parser, error) {
+func NewParser(in io.Reader, bytesToRead int64, frameChannel chan *frame.Frame) (*Parser, error) {
 	reader, err := dicomio.NewReader(bufio.NewReader(in), binary.LittleEndian, bytesToRead)
 	if err != nil {
 		return nil, err
 	}
 
-	p := parser{
+	p := Parser{
 		reader:       reader,
 		frameChannel: frameChannel,
 	}
@@ -58,11 +81,24 @@ func NewParser(in io.Reader, bytesToRead int64, frameChannel chan *frame.Frame) 
 
 	p.dataset = Dataset{Elements: elems}
 
+	// Determine and set the transfer syntax based on the metadata elements parsed so far.
+	ts, err := p.dataset.FindElementByTag(tag.TransferSyntaxUID)
+	if err != nil {
+		// proceed with a default?
+		log.Println("WARN: could not find transfer syntax uid in metadata, proceeding with little endian implicit")
+	}
+	bo, implicit, err := uid.ParseTransferSyntaxUID(MustGetStrings(ts.Value)[0])
+	if err != nil {
+		// proceed with a default?
+		log.Println("WARN: could not parse transfer syntax uid in metadata, proceeding with little endian implicit")
+	}
+	p.reader.SetTransferSyntax(bo, implicit)
+
 	return &p, nil
 }
 
 // readHeader reads the DICOM magic header and group two metadata elements.
-func (p *parser) readHeader() ([]*Element, error) {
+func (p *Parser) readHeader() ([]*Element, error) {
 	// Must read as LittleEndian explicit VR
 	err := p.reader.Skip(128) // skip preamble
 	if err != nil {
@@ -110,46 +146,35 @@ func (p *parser) readHeader() ([]*Element, error) {
 	return metaElems, nil
 }
 
-func (p *parser) Parse() (Dataset, error) {
-	// Determine and set the transfer syntax based on the metadata elements parsed so far.
-	ts, err := p.dataset.FindElementByTag(tag.TransferSyntaxUID)
-	if err != nil {
-		// proceed with a default?
-		log.Println("WARN: could not find transfer syntax uid in metadata, proceeding with little endian implicit")
+// Next parses and returns the next top-level element from the DICOM this Parser points to.
+func (p *Parser) Next() (*Element, error) {
+	if p.reader.IsLimitExhausted() {
+		// Close the frameChannel if needed
+		if p.frameChannel != nil {
+			close(p.frameChannel)
+		}
+		return nil, ErrorEndOfDICOM
 	}
-	bo, implicit, err := uid.ParseTransferSyntaxUID(MustGetStrings(ts.Value)[0])
+	elem, err := readElement(p.reader, &p.dataset, p.frameChannel)
 	if err != nil {
-		// proceed with a default?
-		log.Println("WARN: could not parse transfer syntax uid in metadata, proceeding with little endian implicit")
+		// TODO: tolerate some kinds of errors and continue parsing
+		return nil, err
 	}
-	p.reader.SetTransferSyntax(bo, implicit)
-	for !p.reader.IsLimitExhausted() {
-		// TODO: avoid silent looping
-		elem, err := readElement(p.reader, &p.dataset, p.frameChannel)
+
+	// TODO: add dicom options to only keep track of certain tags
+
+	if elem.Tag == tag.SpecificCharacterSet {
+		encodingNames := MustGetStrings(elem.Value)
+		cs, err := charset.ParseSpecificCharacterSet(encodingNames)
 		if err != nil {
-			// TODO: tolerate some kinds of errors and continue parsing
-			return Dataset{}, err
+			// unable to parse character set, hard error
+			// TODO: add option continue, even if unable to parse
+			return nil, err
 		}
-
-		// TODO: add dicom options to only keep track of certain tags
-
-		if elem.Tag == tag.SpecificCharacterSet {
-			encodingNames := MustGetStrings(elem.Value)
-			cs, err := charset.ParseSpecificCharacterSet(encodingNames)
-			if err != nil {
-				// unable to parse character set, hard error
-				// TODO: add option continue, even if unable to parse
-				return p.dataset, err
-			}
-			p.reader.SetCodingSystem(cs)
-		}
-
-		p.dataset.Elements = append(p.dataset.Elements, elem)
-
+		p.reader.SetCodingSystem(cs)
 	}
 
-	if p.frameChannel != nil {
-		close(p.frameChannel)
-	}
-	return p.dataset, nil
+	p.dataset.Elements = append(p.dataset.Elements, elem)
+	return elem, nil
+
 }


### PR DESCRIPTION
This updates the Parse API for the dicom package. 

For parsing the dataset at once, simply call `dicom.Parse(...)`
```go
// Parse parses the entire DICOM at the input io.Reader into a Dataset of DICOM Elements. Use this if you are
// looking to parse the DICOM all at once, instead of element-by-element.
func Parse(in io.Reader, bytesToRead int64, frameChan chan *frame.Frame) (Dataset, error)
```
```go
data, err := dicom.Parse(...)
```

If you need to parse element-by-element, simply use the `dicom.Parser`:
```go
p, err := dicom.NewParser(...) // This parses the DICOM header and metadata
element, err := p.Next() 
meta := p.GetMetadata()  // if you need it.
...
```