### PR TITLE
Support reading non-standard DICOMs without magic word

### DIFF
--- a/mocks/pkg/dicomio/mock_reader.go
+++ b/mocks/pkg/dicomio/mock_reader.go
@@ -183,6 +183,21 @@ func (mr *MockReaderMockRecorder) Skip(n interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Skip", reflect.TypeOf((*MockReader)(nil).Skip), n)
 }
 
+// Peek mocks base method
+func (m *MockReader) Peek(n int) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Peek", n)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Peek indicates an expected call of Peek
+func (mr *MockReaderMockRecorder) Peek(n interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Peek", reflect.TypeOf((*MockReader)(nil).Peek), n)
+}
+
 // PushLimit mocks base method
 func (m *MockReader) PushLimit(n int64) error {
 	m.ctrl.T.Helper()

--- a/parse.go
+++ b/parse.go
@@ -85,19 +85,20 @@ func NewParser(in io.Reader, bytesToRead int64, frameChannel chan *frame.Frame) 
 	p.metadata = Dataset{Elements: elems}
 
 	// Determine and set the transfer syntax based on the metadata elements parsed so far.
-	// The default will be LittleEndian Implicit
+	// The default will be LittleEndian Implicit.
 	var bo binary.ByteOrder = binary.LittleEndian
 	implicit := true
 
 	ts, err := p.dataset.FindElementByTag(tag.TransferSyntaxUID)
 	if err != nil {
-		// proceed with a default?
 		log.Println("WARN: could not find transfer syntax uid in metadata, proceeding with little endian implicit")
 	} else {
 		bo, implicit, err = uid.ParseTransferSyntaxUID(MustGetStrings(ts.Value)[0])
 		if err != nil {
-			// proceed with a default?
 			log.Println("WARN: could not parse transfer syntax uid in metadata, proceeding with little endian implicit")
+			// TODO(suyashkumar): streamline the defaults
+			bo = binary.LittleEndian
+			implicit = true
 		}
 	}
 	p.reader.SetTransferSyntax(bo, implicit)

--- a/read_test.go
+++ b/read_test.go
@@ -1,11 +1,13 @@
 package dicom
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"github.com/suyashkumar/dicom/pkg/dicomio"
 	"testing"
+
+	"github.com/suyashkumar/dicom/pkg/dicomio"
 
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-cmp/cmp"
@@ -34,25 +36,25 @@ func TestReadTag(t *testing.T) {
 }
 
 func TestReadFloat_float64(t *testing.T) {
-	cases := []struct{
-		name string
-		floats []float64
-		VR string
-		want Value
+	cases := []struct {
+		name        string
+		floats      []float64
+		VR          string
+		want        Value
 		expectedErr error
 	}{
 		{
-			name: "float64",
-			floats:[]float64{20.1, 32.22},
-			VR: "FD",
-			want: &floatsValue{value: []float64{20.1, 32.22}},
+			name:        "float64",
+			floats:      []float64{20.1, 32.22},
+			VR:          "FD",
+			want:        &floatsValue{value: []float64{20.1, 32.22}},
 			expectedErr: nil,
 		},
 		{
-			name: "float64 with wrong VR",
-			floats:[]float64{20.1, 32.22},
-			VR: "XX",
-			want: nil,
+			name:        "float64 with wrong VR",
+			floats:      []float64{20.1, 32.22},
+			VR:          "XX",
+			want:        nil,
 			expectedErr: errorUnableToParseFloat,
 		},
 	}
@@ -66,7 +68,7 @@ func TestReadFloat_float64(t *testing.T) {
 				}
 			}
 
-			r, err := dicomio.NewReader(&data, binary.LittleEndian, int64(data.Len()))
+			r, err := dicomio.NewReader(bufio.NewReader(&data), binary.LittleEndian, int64(data.Len()))
 			if err != nil {
 				t.Errorf("TestReadFloat: unable to create new dicomio.Reader")
 			}
@@ -83,25 +85,25 @@ func TestReadFloat_float64(t *testing.T) {
 }
 
 func TestReadFloat_float32(t *testing.T) {
-	cases := []struct{
-		name string
-		floats []float32
-		VR string
-		want Value
+	cases := []struct {
+		name        string
+		floats      []float32
+		VR          string
+		want        Value
 		expectedErr error
 	}{
 		{
-			name: "float32",
-			floats:[]float32{20.1001, 32.22},
-			VR: "FL",
-			want: &floatsValue{value: []float64{20.1001, 32.22}},
+			name:        "float32",
+			floats:      []float32{20.1001, 32.22},
+			VR:          "FL",
+			want:        &floatsValue{value: []float64{20.1001, 32.22}},
 			expectedErr: nil,
 		},
 		{
-			name: "float32 with wrong VR",
-			floats:[]float32{20.1001, 32.22},
-			VR: "XX",
-			want: nil,
+			name:        "float32 with wrong VR",
+			floats:      []float32{20.1001, 32.22},
+			VR:          "XX",
+			want:        nil,
 			expectedErr: errorUnableToParseFloat,
 		},
 	}
@@ -115,7 +117,7 @@ func TestReadFloat_float32(t *testing.T) {
 				}
 			}
 
-			r, err := dicomio.NewReader(&data, binary.LittleEndian, int64(data.Len()))
+			r, err := dicomio.NewReader(bufio.NewReader(&data), binary.LittleEndian, int64(data.Len()))
 			if err != nil {
 				t.Errorf("TestReadFloat: unable to create new dicomio.Reader")
 			}

--- a/write.go
+++ b/write.go
@@ -1,6 +1,7 @@
 package dicom
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/binary"
 	"errors"
@@ -104,7 +105,7 @@ func writeFileHeader(w dicomio.Writer, ds *Dataset, metaElems []*Element, opts .
 		return err
 	}
 	err = writeMetaElem(subWriter, tag.MediaStorageSOPClassUID, ds, &tagsUsed, opts...)
-	if err != nil && err != ErrorElementNotFound{
+	if err != nil && err != ErrorElementNotFound {
 		return err
 	}
 	err = writeMetaElem(subWriter, tag.MediaStorageSOPInstanceUID, ds, &tagsUsed, opts...)
@@ -173,8 +174,8 @@ func writeElement(w dicomio.Writer, elem *Element, opts ...WriteOption) error {
 
 	length := uint32(len(data.Bytes()))
 	if elem.ValueLength == tag.VLUndefinedLength {
-		length = tag.VLUndefinedLength 
-	}	
+		length = tag.VLUndefinedLength
+	}
 
 	err = encodeElementHeader(w, elem.Tag, vr, length)
 	if err != nil {
@@ -252,7 +253,7 @@ func verifyValueType(t tag.Tag, value Value, valueType ValueType, vr string) err
 }
 
 func writeTag(w dicomio.Writer, t tag.Tag, vl uint32) error {
-	if vl%2 != 0  && vl != tag.VLUndefinedLength {
+	if vl%2 != 0 && vl != tag.VLUndefinedLength {
 		return fmt.Errorf("ERROR dicomio.writeTag: Value Length must be even, but for Tag=%v, ValueLength=%v",
 			tag.DebugString(t), vl)
 	}
@@ -487,7 +488,7 @@ func writeOtherWordString(w dicomio.Writer, data []byte) error {
 		return ErrorOWRequiresEvenVL
 	}
 	bo, _ := w.GetTransferSyntax()
-	r, err := dicomio.NewReader(bytes.NewBuffer(data), bo, int64(len(data)))
+	r, err := dicomio.NewReader(bufio.NewReader(bytes.NewBuffer(data)), bo, int64(len(data)))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This change adds some support to read non-standard DICOMs that do not include the magic word at offset 128 (as described in #59). 

This change attempts to peek ahead at the magic word to see if it is there. If not, it effectively rewinds back to byte zero, skips metadata parsing, and goes back to typical parsing (with a transfer syntax default of LittleEndian Implicit). 

While some of the non-standard dicoms in #59 appear to be broken in other unrelated ways, most of them work with this fix.