### PR TITLE
Add benchmarks over testfiles/

### DIFF
--- a/parse_test.go
+++ b/parse_test.go
@@ -52,10 +52,12 @@ func BenchmarkParse(b *testing.B) {
 					b.Errorf("Unable to open %s. Error: %v", f.Name(), err)
 				}
 				defer dcm.Close()
+
 				data, err := ioutil.ReadAll(dcm)
 				if err != nil {
 					b.Errorf("Unable to read file into memory for benchmark: %v", err)
 				}
+
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
 					_, _ = dicom.Parse(bytes.NewBuffer(data), int64(len(data)), nil)

--- a/parse_test.go
+++ b/parse_test.go
@@ -1,6 +1,7 @@
 package dicom_test
 
 import (
+	"bytes"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -31,6 +32,29 @@ func TestParse(t *testing.T) {
 				_, err = dicom.Parse(dcm, info.Size(), nil)
 				if err != nil {
 					t.Errorf("dicom.Parse(%s) unexpected error: %v", f.Name(), err)
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkParse(b *testing.B) {
+	files, err := ioutil.ReadDir("./testfiles")
+	if err != nil {
+		b.Fatalf("unable to read testfiles/: %v", err)
+	}
+	for _, f := range files {
+		if !f.IsDir() && strings.HasSuffix(f.Name(), ".dcm") {
+			b.Run(f.Name(), func(b *testing.B) {
+				dcm, err := os.Open("./testfiles/" + f.Name())
+				if err != nil {
+					b.Errorf("Unable to open %s. Error: %v", f.Name(), err)
+				}
+				defer dcm.Close()
+				data, err := ioutil.ReadAll(dcm)
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					_, _ = dicom.Parse(bytes.NewBuffer(data), int64(len(data)), nil)
 				}
 			})
 		}

--- a/parse_test.go
+++ b/parse_test.go
@@ -38,6 +38,7 @@ func TestParse(t *testing.T) {
 	}
 }
 
+// BenchmarkParse runs sanity benchmarks over the sample files in testfiles.
 func BenchmarkParse(b *testing.B) {
 	files, err := ioutil.ReadDir("./testfiles")
 	if err != nil {
@@ -52,6 +53,9 @@ func BenchmarkParse(b *testing.B) {
 				}
 				defer dcm.Close()
 				data, err := ioutil.ReadAll(dcm)
+				if err != nil {
+					b.Errorf("Unable to read file into memory for benchmark: %v", err)
+				}
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
 					_, _ = dicom.Parse(bytes.NewBuffer(data), int64(len(data)), nil)


### PR DESCRIPTION
This adds initial basic benchmarks over `testfiles/`. 

In the future, we can add a GitHub action to use benchstat to compare benchmark diffs.