### PR TITLE
write: implement support for missing TransferSyntax with option

### DIFF
--- a/write.go
+++ b/write.go
@@ -131,14 +131,14 @@ func writeFileHeader(w dicomio.Writer, ds *Dataset, metaElems []*Element, opts w
 		return err
 	}
 	err = writeMetaElem(subWriter, tag.TransferSyntaxUID, ds, &tagsUsed, opts)
+	if err != nil && err != ErrorElementNotFound || err == ErrorElementNotFound && !opts.defaultMissingTransferSyntax {
+		return err
+	}
 	if err == ErrorElementNotFound && opts.defaultMissingTransferSyntax {
 		// Write the default transfer syntax
 		if err = writeElement(subWriter, mustNewElement(tag.TransferSyntaxUID, []string{uid.ImplicitVRLittleEndian}), opts); err != nil {
 			return err
 		}
-		tagsUsed[tag.TransferSyntaxUID] = true
-	} else if err != nil {
-		return err
 	}
 
 	for _, elem := range metaElems {


### PR DESCRIPTION
This change allows writing of a Dataset without a TransferSyntax metadata element, so long as the DefaultMissingTransferSyntax option is provided to `Write`.

This fixes #132. 