### PR TITLE
write: Support for writing Sequences, and other misc write package improvements.

### DIFF
--- a/dataset_test.go
+++ b/dataset_test.go
@@ -14,8 +14,9 @@ func makeSequenceElement(tg tag.Tag, items [][]*Element) *Element {
 	}
 
 	return &Element{
-		Tag:                 tg,
-		ValueRepresentation: tag.VRSequence,
+		Tag:                    tg,
+		ValueRepresentation:    tag.VRSequence,
+		RawValueRepresentation: "SQ",
 		Value: &sequencesValue{
 			value: sequenceItems,
 		},

--- a/element_test.go
+++ b/element_test.go
@@ -23,7 +23,7 @@ func TestElement_MarshalJSON_NestedElements(t *testing.T) {
 	}
 	seqElement := makeSequenceElement(tag.AddOtherSequence, nestedData)
 
-	want := `{"tag":{"Group":70,"Element":258},"VR":9,"rawVR":"","valueLength":0,"value":[[{"tag":{"Group":16,"Element":16},"VR":2,"rawVR":"","valueLength":0,"value":["Bob"]}]]}`
+	want := `{"tag":{"Group":70,"Element":258},"VR":9,"rawVR":"SQ","valueLength":0,"value":[[{"tag":{"Group":16,"Element":16},"VR":2,"rawVR":"","valueLength":0,"value":["Bob"]}]]}`
 
 	j, err := json.Marshal(seqElement)
 	if err != nil {

--- a/pkg/dicomio/writer.go
+++ b/pkg/dicomio/writer.go
@@ -7,7 +7,7 @@ import (
 
 // Writer is a lower level encoder that takes abstracted input and writes it at the byte-level
 type Writer interface {
-	SetTransferSynax(bo binary.ByteOrder, implicit bool)
+	SetTransferSyntax(bo binary.ByteOrder, implicit bool)
 	WriteZeros(len int)
 	WriteString(v string)
 	WriteByte(v byte)
@@ -34,7 +34,7 @@ func NewWriter(out io.Writer, bo binary.ByteOrder, implicit bool) Writer {
 	}
 }
 
-func (w *writer) SetTransferSynax(bo binary.ByteOrder, implicit bool) {
+func (w *writer) SetTransferSyntax(bo binary.ByteOrder, implicit bool) {
 	w.bo = bo
 	w.implicit = implicit
 }

--- a/read.go
+++ b/read.go
@@ -281,6 +281,7 @@ func readSequence(r dicomio.Reader, t tag.Tag, vr string, vl uint32) (Value, err
 			if subElement.Tag != tag.Item || subElement.Value.ValueType() != SequenceItem {
 				// This is an error, should be an Item!
 				// TODO: use error var
+				log.Println("Tag is ", subElement.Tag)
 				return nil, fmt.Errorf("non item found in sequence")
 			}
 

--- a/write.go
+++ b/write.go
@@ -360,11 +360,6 @@ func writeValue(w dicomio.Writer, t tag.Tag, value Value, valueType ValueType, v
 		return fmt.Errorf("encoding undefined-length element not yet supported: %v", t)
 	}
 
-	if t == tag.SequenceDelimitationItem || t == tag.ItemDelimitationItem {
-		// We don't write any values for these items, so we return immediately.
-		return nil
-	}
-
 	v := value.GetValue()
 	switch valueType {
 	case Strings:
@@ -548,12 +543,12 @@ var item = &Element{
 }
 
 func writeSequenceItem(w dicomio.Writer, t tag.Tag, values []*Element, vr string, vl uint32, opts writeOptSet) error {
-	// Write out item header
+	// Write out item header.
 	if err := writeElement(w, item, opts); err != nil {
 		return err
 	}
 
-	// Write out nested Dataset elements
+	// Write out nested Dataset elements.
 	for _, elem := range values {
 		if err := writeElement(w, elem, opts); err != nil {
 			return err

--- a/write.go
+++ b/write.go
@@ -20,7 +20,8 @@ var (
 	// ErrorMismatchValueTypeAndVR is for when there's a discrepency betweeen the ValueType and what the VR specifies.
 	ErrorMismatchValueTypeAndVR = errors.New("ValueType does not match the VR required")
 	// ErrorUnexpectedValueType indicates an unexpected value type was seen.
-	ErrorUnexpectedValueType = errors.New("Unexpected ValueType")
+	ErrorUnexpectedValueType      = errors.New("Unexpected ValueType")
+	ErrorUnsupportedBitsPerSample = errors.New("unsupported BitsPerSample value")
 )
 
 // TODO(suyashkumar): consider adding an element-by-element write API.
@@ -48,9 +49,9 @@ func Write(out io.Writer, ds Dataset, opts ...WriteOption) error {
 	}
 
 	if err == ErrorElementNotFound && optSet.defaultMissingTransferSyntax {
-		w.SetTransferSynax(binary.LittleEndian, true)
+		w.SetTransferSyntax(binary.LittleEndian, true)
 	} else {
-		w.SetTransferSynax(endian, implicit)
+		w.SetTransferSyntax(endian, implicit)
 	}
 
 	for _, elem := range ds.Elements {
@@ -111,7 +112,7 @@ func toOptSet(opts ...WriteOption) *writeOptSet {
 
 func writeFileHeader(w dicomio.Writer, ds *Dataset, metaElems []*Element, opts writeOptSet) error {
 	// File headers are always written in littleEndian explicit
-	w.SetTransferSynax(binary.LittleEndian, false)
+	w.SetTransferSyntax(binary.LittleEndian, false)
 
 	metaBytes := &bytes.Buffer{}
 	subWriter := dicomio.NewWriter(metaBytes, binary.LittleEndian, false)
@@ -177,34 +178,38 @@ func writeElement(w dicomio.Writer, elem *Element, opts writeOptSet) error {
 			return err
 		}
 	}
-	if !opts.skipValueTypeVerification {
+	if !opts.skipValueTypeVerification && elem.Value != nil {
 		err := verifyValueType(elem.Tag, elem.Value, vr)
 		if err != nil {
 			return err
 		}
 	}
 
-	// writeValue to subwriter
-	bo, implicit := w.GetTransferSyntax()
-	data := &bytes.Buffer{}
-	subWriter := dicomio.NewWriter(data, bo, implicit)
-	err := writeValue(subWriter, elem.Tag, elem.Value, elem.Value.ValueType(), vr, elem.ValueLength, opts)
+	length := elem.ValueLength
+	var valueData = &bytes.Buffer{}
+	if elem.Value != nil {
+		bo, implicit := w.GetTransferSyntax()
+		subWriter := dicomio.NewWriter(valueData, bo, implicit)
+		err := writeValue(subWriter, elem.Tag, elem.Value, elem.Value.ValueType(), vr, elem.ValueLength, opts)
+		if err != nil {
+			return err
+		}
+
+		length = uint32(len(valueData.Bytes()))
+		if elem.ValueLength == tag.VLUndefinedLength {
+			length = tag.VLUndefinedLength
+		}
+	}
+
+	err := encodeElementHeader(w, elem.Tag, vr, length)
 	if err != nil {
 		return err
 	}
 
-	length := uint32(len(data.Bytes()))
-	if elem.ValueLength == tag.VLUndefinedLength {
-		length = tag.VLUndefinedLength
+	if elem.Value != nil {
+		// Write the bytes to the original writer
+		w.WriteBytes(valueData.Bytes())
 	}
-
-	err = encodeElementHeader(w, elem.Tag, vr, length)
-	if err != nil {
-		return err
-	}
-
-	// Write the bytes to the original writer
-	w.WriteBytes(data.Bytes())
 	return nil
 }
 
@@ -277,21 +282,18 @@ func writeTag(w dicomio.Writer, t tag.Tag, vl uint32) error {
 	return nil
 }
 
-// TODO vl is a pointer so that we can alter the data in the original element
-// so that later, we can check if elem.VL == tag.VLUndefinedLength
-// Need to find a better solution for this
-func writeVRVL(w dicomio.Writer, t tag.Tag, vr string, vl *uint32) error {
+func writeVRVL(w dicomio.Writer, t tag.Tag, vr string, vl uint32) error {
 	// Rectify Undefined Length VL
-	if *vl == 0xffff {
-		// TODO: Ask suyash if it's okay to alter the actual element passed in
-		// Another option (1) is to make a copy of elem passed in insetad of taking
-		// a pointer element in writeElement
-		// Option (2) is to just pass through vl and vr
-		undefined := tag.VLUndefinedLength
-		vl = &undefined
+	if vl == 0xffff {
+		vl = tag.VLUndefinedLength
 	}
 
-	if len(vr) != 2 && *vl != tag.VLUndefinedLength && t != tag.SequenceDelimitationItem {
+	if vr == "SQ" || t == tag.Item {
+		// We are going to write these out with undefined length always.
+		vl = tag.VLUndefinedLength
+	}
+
+	if len(vr) != 2 && vl != tag.VLUndefinedLength && t != tag.SequenceDelimitationItem {
 		return fmt.Errorf("ERROR dicomio.writeVRVL: Value Representation must be of length 2, e.g. 'UN'. For tag=%v, it was RawValueRepresentation=%v",
 			tag.DebugString(t), vr)
 	}
@@ -306,31 +308,39 @@ func writeVRVL(w dicomio.Writer, t tag.Tag, vr string, vl *uint32) error {
 		switch vr {
 		case "NA", "OB", "OD", "OF", "OL", "OW", "SQ", "UN", "UC", "UR", "UT":
 			w.WriteZeros(2)
-			w.WriteUInt32(*vl)
+			w.WriteUInt32(vl)
 		default:
-			w.WriteUInt16(uint16(*vl))
+			w.WriteUInt16(uint16(vl))
 		}
 	} else {
-		w.WriteUInt32(*vl)
+		w.WriteUInt32(vl)
 	}
 	return nil
 }
 
-func writeRawItem(w dicomio.Writer, data []byte) {
+func writeRawItem(w dicomio.Writer, data []byte) error {
 	length := uint32(len(data))
-	writeTag(w, tag.Item, length)
-	writeVRVL(w, tag.Item, "NA", &length)
+	if err := writeTag(w, tag.Item, length); err != nil {
+		return err
+	}
+	if err := writeVRVL(w, tag.Item, "NA", length); err != nil {
+		return err
+	}
 	w.WriteBytes(data)
+	return nil
 }
 
-func writeBasicOffsetTable(w dicomio.Writer, offsets []uint32) {
+func writeBasicOffsetTable(w dicomio.Writer, offsets []uint32) error {
 	byteOrder, implicit := w.GetTransferSyntax()
 	data := &bytes.Buffer{}
 	subWriter := dicomio.NewWriter(data, byteOrder, implicit)
 	for _, offset := range offsets {
 		subWriter.WriteUInt32(offset)
 	}
-	writeRawItem(w, data.Bytes())
+	if err := writeRawItem(w, data.Bytes()); err != nil {
+		return err
+	}
+	return nil
 }
 
 func encodeElementHeader(w dicomio.Writer, t tag.Tag, vr string, vl uint32) error {
@@ -338,7 +348,7 @@ func encodeElementHeader(w dicomio.Writer, t tag.Tag, vr string, vl uint32) erro
 	if err != nil {
 		return err
 	}
-	err = writeVRVL(w, t, vr, &vl)
+	err = writeVRVL(w, t, vr, vl)
 	if err != nil {
 		return err
 	}
@@ -348,6 +358,11 @@ func encodeElementHeader(w dicomio.Writer, t tag.Tag, vr string, vl uint32) erro
 func writeValue(w dicomio.Writer, t tag.Tag, value Value, valueType ValueType, vr string, vl uint32, opts writeOptSet) error {
 	if vl == tag.VLUndefinedLength && valueType <= 2 { // strings, bytes or ints
 		return fmt.Errorf("encoding undefined-length element not yet supported: %v", t)
+	}
+
+	if t == tag.SequenceDelimitationItem || t == tag.ItemDelimitationItem {
+		// We don't write any values for these items, so we return immediately.
+		return nil
 	}
 
 	v := value.GetValue()
@@ -450,9 +465,13 @@ func writeFloats(w dicomio.Writer, v Value, vr string) error {
 func writePixelData(w dicomio.Writer, t tag.Tag, value Value, vr string, vl uint32) error {
 	image := MustGetPixelDataInfo(value)
 	if vl == tag.VLUndefinedLength {
-		writeBasicOffsetTable(w, image.Offsets)
+		if err := writeBasicOffsetTable(w, image.Offsets); err != nil {
+			return err
+		}
 		for _, frame := range image.Frames {
-			writeRawItem(w, frame.EncapsulatedData.Data)
+			if err := writeRawItem(w, frame.EncapsulatedData.Data); err != nil {
+				return err
+			}
 		}
 		err := encodeElementHeader(w, tag.SequenceDelimitationItem, "", 0)
 		if err != nil {
@@ -470,9 +489,15 @@ func writePixelData(w dicomio.Writer, t tag.Tag, value Value, vr string, vl uint
 			for pixel := 0; pixel < numPixels; pixel++ {
 				for value := 0; value < numValues; value++ {
 					if image.Frames[frame].NativeData.BitsPerSample == 8 {
-						binary.Write(buf, binary.LittleEndian, uint8(image.Frames[frame].NativeData.Data[pixel][value]))
+						if err := binary.Write(buf, binary.LittleEndian, uint8(image.Frames[frame].NativeData.Data[pixel][value])); err != nil {
+							return err
+						}
 					} else if image.Frames[frame].NativeData.BitsPerSample == 16 {
-						binary.Write(buf, binary.LittleEndian, uint16(image.Frames[frame].NativeData.Data[pixel][value]))
+						if err := binary.Write(buf, binary.LittleEndian, uint16(image.Frames[frame].NativeData.Data[pixel][value])); err != nil {
+							return err
+						}
+					} else {
+						return ErrorUnsupportedBitsPerSample
 					}
 				}
 			}
@@ -482,14 +507,65 @@ func writePixelData(w dicomio.Writer, t tag.Tag, value Value, vr string, vl uint
 	return nil
 }
 
-// TODO implement
-func writeSequence(w dicomio.Writer, t tag.Tag, values []*SequenceItemValue, vr string, vl uint32, opts writeOptSet) error {
-	return ErrorUnimplemented
+var sequenceDelimitationItem = &Element{
+	Tag:         tag.SequenceDelimitationItem,
+	ValueLength: 0, // This should be 00000000H in base32
 }
 
-// TODO implement
+func writeSequence(w dicomio.Writer, t tag.Tag, values []*SequenceItemValue, vr string, vl uint32, opts writeOptSet) error {
+	// We always write out sequences using the undefined length encoding.
+	// Note: we currently don't validate that the length of the sequence matches
+	// the VL if it's not undefined VL.
+	// More details about the sequence structure can be found at:
+	// http://dicom.nema.org/medical/dicom/current/output/chtml/part05/sect_7.5.html
+
+	// Write out the items.
+	for _, seqItem := range values {
+		if err := writeSequenceItem(w, t, seqItem.elements, vr, vl, opts); err != nil {
+			return err
+		}
+	}
+
+	// Write Sequence Delimitation Item as implicit VR
+	oldBO, oldImplicit := w.GetTransferSyntax()
+	w.SetTransferSyntax(oldBO, true)
+	if err := writeElement(w, sequenceDelimitationItem, opts); err != nil {
+		return err
+	}
+	w.SetTransferSyntax(oldBO, oldImplicit) // Return TS to what it was before.
+
+	return nil
+}
+
+var sequenceItemDelimitationItem = &Element{
+	Tag:         tag.ItemDelimitationItem,
+	ValueLength: 0, // This should be 00000000H in base32
+}
+
+var item = &Element{
+	Tag:         tag.Item,
+	ValueLength: tag.VLUndefinedLength,
+}
+
 func writeSequenceItem(w dicomio.Writer, t tag.Tag, values []*Element, vr string, vl uint32, opts writeOptSet) error {
-	return ErrorUnimplemented
+	// Write out item header
+	if err := writeElement(w, item, opts); err != nil {
+		return err
+	}
+
+	// Write out nested Dataset elements
+	for _, elem := range values {
+		if err := writeElement(w, elem, opts); err != nil {
+			return err
+		}
+	}
+
+	// Write ItemDelimitationItem.
+	if err := writeElement(w, sequenceItemDelimitationItem, opts); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func writeOtherWordString(w dicomio.Writer, data []byte) error {

--- a/write_test.go
+++ b/write_test.go
@@ -31,21 +31,21 @@ func TestWrite(t *testing.T) {
 				mustNewElement(tag.MediaStorageSOPClassUID, []string{"1.2.840.10008.5.1.4.1.1.1.2"}),
 				mustNewElement(tag.MediaStorageSOPInstanceUID, []string{"1.2.3.4.5.6.7"}),
 				mustNewElement(tag.TransferSyntaxUID, []string{uid.ImplicitVRLittleEndian}),
-				mustNewElement(tag.PatientName, []string{"Robin Banks"}),
+				mustNewElement(tag.PatientName, []string{"Bob", "Jones"}),
 				mustNewElement(tag.Rows, []int{128}),
 				mustNewElement(tag.FloatingPointValue, []float64{128.10}),
 			}},
 			expectedError: nil,
 		},
 		{
-			name: "basic types with sequence (2 Items with 2 values each)",
+			name: "sequence (2 Items with 2 values each)",
 			dataset: Dataset{Elements: []*Element{
 				mustNewElement(tag.MediaStorageSOPClassUID, []string{"1.2.840.10008.5.1.4.1.1.1.2"}),
 				mustNewElement(tag.MediaStorageSOPInstanceUID, []string{"1.2.3.4.5.6.7"}),
 				mustNewElement(tag.TransferSyntaxUID, []string{uid.ImplicitVRLittleEndian}),
-				mustNewElement(tag.PatientName, []string{"Robin Banks"}),
+				mustNewElement(tag.PatientName, []string{"Bob", "Jones"}),
 				makeSequenceElement(tag.AddOtherSequence, [][]*Element{
-					// Item 1
+					// Item 1.
 					{
 						{
 							Tag:                    tag.PatientName,
@@ -64,7 +64,7 @@ func TestWrite(t *testing.T) {
 							},
 						},
 					},
-					// Item 2
+					// Item 2.
 					{
 						{
 							Tag:                    tag.PatientName,
@@ -88,11 +88,47 @@ func TestWrite(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			name: "nested sequences",
+			dataset: Dataset{Elements: []*Element{
+				mustNewElement(tag.MediaStorageSOPClassUID, []string{"1.2.840.10008.5.1.4.1.1.1.2"}),
+				mustNewElement(tag.MediaStorageSOPInstanceUID, []string{"1.2.3.4.5.6.7"}),
+				mustNewElement(tag.TransferSyntaxUID, []string{uid.ImplicitVRLittleEndian}),
+				mustNewElement(tag.PatientName, []string{"Bob", "Jones"}),
+				makeSequenceElement(tag.AddOtherSequence, [][]*Element{
+					// Item 1.
+					{
+						{
+							Tag:                    tag.PatientName,
+							ValueRepresentation:    tag.VRStringList,
+							RawValueRepresentation: "PN",
+							Value: &stringsValue{
+								value: []string{"Bob", "Jones"},
+							},
+						},
+						// Nested Sequence.
+						makeSequenceElement(tag.AnatomicRegionSequence, [][]*Element{
+							{
+								{
+									Tag:                    tag.PatientName,
+									ValueRepresentation:    tag.VRStringList,
+									RawValueRepresentation: "PN",
+									Value: &stringsValue{
+										value: []string{"Bob", "Jones"},
+									},
+								},
+							},
+						}),
+					},
+				}),
+			}},
+			expectedError: nil,
+		},
+		{
 			name: "without transfer syntax",
 			dataset: Dataset{Elements: []*Element{
 				mustNewElement(tag.MediaStorageSOPClassUID, []string{"1.2.840.10008.5.1.4.1.1.1.2"}),
 				mustNewElement(tag.MediaStorageSOPInstanceUID, []string{"1.2.3.4.5.6.7"}),
-				mustNewElement(tag.PatientName, []string{"Robin Banks"}),
+				mustNewElement(tag.PatientName, []string{"Bob", "Jones"}),
 				mustNewElement(tag.Rows, []int{128}),
 				mustNewElement(tag.FloatingPointValue, []float64{128.10}),
 			}},
@@ -103,7 +139,7 @@ func TestWrite(t *testing.T) {
 			dataset: Dataset{Elements: []*Element{
 				mustNewElement(tag.MediaStorageSOPClassUID, []string{"1.2.840.10008.5.1.4.1.1.1.2"}),
 				mustNewElement(tag.MediaStorageSOPInstanceUID, []string{"1.2.3.4.5.6.7"}),
-				mustNewElement(tag.PatientName, []string{"Robin Banks"}),
+				mustNewElement(tag.PatientName, []string{"Bob", "Jones"}),
 				mustNewElement(tag.Rows, []int{128}),
 				mustNewElement(tag.FloatingPointValue, []float64{128.10}),
 			}},
@@ -161,14 +197,6 @@ func TestWrite(t *testing.T) {
 		})
 	}
 }
-
-func TestEncodeElementHeader(t *testing.T) {}
-
-func TestWriteValue(t *testing.T) {}
-
-func TestWriteTag(t *testing.T) {}
-
-func TestWriteVRVL(t *testing.T) {}
 
 func TestVerifyVR(t *testing.T) {
 	cases := []struct {

--- a/write_test.go
+++ b/write_test.go
@@ -16,12 +16,6 @@ import (
 	"github.com/suyashkumar/dicom/pkg/uid"
 )
 
-/*
-FURTHER TESTING
-	- Read written values back in and verify Datsets are the same
-	- With 'wild' DICOMs with high variability, read in, write out, read in, and verify
-*/
-
 func TestWrite(t *testing.T) {
 	cases := []struct {
 		name          string
@@ -29,6 +23,7 @@ func TestWrite(t *testing.T) {
 		extraElems    []*Element
 		expectedError error
 		opts          []WriteOption
+		cmpOpts       []cmp.Option
 	}{
 		{
 			name: "basic types",
@@ -39,6 +34,56 @@ func TestWrite(t *testing.T) {
 				mustNewElement(tag.PatientName, []string{"Robin Banks"}),
 				mustNewElement(tag.Rows, []int{128}),
 				mustNewElement(tag.FloatingPointValue, []float64{128.10}),
+			}},
+			expectedError: nil,
+		},
+		{
+			name: "basic types with sequence (2 Items with 2 values each)",
+			dataset: Dataset{Elements: []*Element{
+				mustNewElement(tag.MediaStorageSOPClassUID, []string{"1.2.840.10008.5.1.4.1.1.1.2"}),
+				mustNewElement(tag.MediaStorageSOPInstanceUID, []string{"1.2.3.4.5.6.7"}),
+				mustNewElement(tag.TransferSyntaxUID, []string{uid.ImplicitVRLittleEndian}),
+				mustNewElement(tag.PatientName, []string{"Robin Banks"}),
+				makeSequenceElement(tag.AddOtherSequence, [][]*Element{
+					// Item 1
+					{
+						{
+							Tag:                    tag.PatientName,
+							ValueRepresentation:    tag.VRStringList,
+							RawValueRepresentation: "PN",
+							Value: &stringsValue{
+								value: []string{"Bob", "Jones"},
+							},
+						},
+						{
+							Tag:                    tag.Rows,
+							ValueRepresentation:    tag.VRUInt16List,
+							RawValueRepresentation: "US",
+							Value: &intsValue{
+								value: []int{100},
+							},
+						},
+					},
+					// Item 2
+					{
+						{
+							Tag:                    tag.PatientName,
+							ValueRepresentation:    tag.VRStringList,
+							RawValueRepresentation: "PN",
+							Value: &stringsValue{
+								value: []string{"Bob", "Jones"},
+							},
+						},
+						{
+							Tag:                    tag.Rows,
+							ValueRepresentation:    tag.VRUInt16List,
+							RawValueRepresentation: "US",
+							Value: &intsValue{
+								value: []int{100},
+							},
+						},
+					},
+				}),
 			}},
 			expectedError: nil,
 		},
@@ -96,13 +141,19 @@ func TestWrite(t *testing.T) {
 				}
 
 				wantElems := append(tc.dataset.Elements, tc.extraElems...)
-				if diff := cmp.Diff(
-					readDS.Elements,
-					wantElems,
+
+				cmpOpts := []cmp.Option{
 					cmp.AllowUnexported(allValues...),
 					cmpopts.IgnoreFields(Element{}, "ValueLength"),
 					cmpopts.IgnoreSliceElements(func(e *Element) bool { return e.Tag == tag.FileMetaInformationGroupLength }),
 					cmpopts.SortSlices(func(x, y *Element) bool { return x.Tag.Compare(y.Tag) == 1 }),
+				}
+				cmpOpts = append(cmpOpts, tc.cmpOpts...)
+
+				if diff := cmp.Diff(
+					readDS.Elements,
+					wantElems,
+					cmpOpts...,
 				); diff != "" {
 					t.Errorf("Reading back written dataset led to unexpected diff from source data: %s", diff)
 				}


### PR DESCRIPTION
This change adds support and tests for writing out sequences in the write package. All sequences are written with the undefined length encoding option (http://dicom.nema.org/medical/dicom/current/output/chtml/part05/sect_7.5.html). 

This change also improves other various issues and APIs in the write code. 