### PR TITLE
Initial support for AT Tag

### DIFF
--- a/read.go
+++ b/read.go
@@ -93,7 +93,7 @@ func readValue(r dicomio.Reader, t tag.Tag, vr string, vl uint32, isImplicit boo
 		return readString(r, t, vr, vl)
 	case tag.VRDate:
 		return readDate(r, t, vr, vl)
-	case tag.VRUInt16List, tag.VRUInt32List, tag.VRInt16List, tag.VRInt32List:
+	case tag.VRUInt16List, tag.VRUInt32List, tag.VRInt16List, tag.VRInt32List, tag.VRTagList:
 		return readInt(r, t, vr, vl)
 	case tag.VRSequence:
 		return readSequence(r, t, vr, vl)
@@ -459,7 +459,7 @@ func readInt(r dicomio.Reader, t tag.Tag, vr string, vl uint32) (Value, error) {
 	retVal := &intsValue{value: make([]int, 0, vl/2)}
 	for !r.IsLimitExhausted() {
 		switch vr {
-		case "US":
+		case "US", "AT":
 			val, err := r.ReadUInt16()
 			if err != nil {
 				return nil, err

--- a/write.go
+++ b/write.go
@@ -448,8 +448,7 @@ func writeBytes(w dicomio.Writer, values []byte, vr string) error {
 func writeInts(w dicomio.Writer, values []int, vr string) error {
 	for _, value := range values {
 		switch vr {
-		// TODO(suyashkumar): consider validating that elements with VR=AT only
-		// have two elements in the future.
+		// TODO(suyashkumar): consider additional validation of VR=AT elements.
 		case "US", "SS", "AT":
 			if err := w.WriteUInt16(uint16(value)); err != nil {
 				return err

--- a/write.go
+++ b/write.go
@@ -258,7 +258,7 @@ func verifyValueType(t tag.Tag, value Value, vr string) error {
 	valueType := value.ValueType()
 	var ok bool
 	switch vr {
-	case "US", "UL", "SL", "SS":
+	case "US", "UL", "SL", "SS", "AT":
 		ok = valueType == Ints
 	case "SQ":
 		ok = valueType == Sequences
@@ -272,8 +272,6 @@ func verifyValueType(t tag.Tag, value Value, vr string) error {
 		}
 	case "FL", "FD":
 		ok = valueType == Floats
-	case "AT":
-		fallthrough
 	default:
 		ok = valueType == Strings
 	}
@@ -450,7 +448,9 @@ func writeBytes(w dicomio.Writer, values []byte, vr string) error {
 func writeInts(w dicomio.Writer, values []int, vr string) error {
 	for _, value := range values {
 		switch vr {
-		case "US", "SS":
+		// TODO(suyashkumar): consider validating that elements with VR=AT only
+		// have two elements in the future.
+		case "US", "SS", "AT":
 			if err := w.WriteUInt16(uint16(value)); err != nil {
 				return err
 			}

--- a/write_test.go
+++ b/write_test.go
@@ -16,6 +16,13 @@ import (
 	"github.com/suyashkumar/dicom/pkg/uid"
 )
 
+// TestWrite tests the write package by ensuring that it is consistent with the
+// Parse implementation. In particular, it is tested by writing out known
+// collections of Element and reading them back in using the Parse API and
+// ensuing the read in collection is equal to the initial collection.
+//
+// This also serves to test that the Parse implementation is consistent with the
+// Write implementation (e.g. it kinda goes both ways and covers Parse too).
 func TestWrite(t *testing.T) {
 	cases := []struct {
 		name          string

--- a/write_test.go
+++ b/write_test.go
@@ -34,6 +34,7 @@ func TestWrite(t *testing.T) {
 				mustNewElement(tag.PatientName, []string{"Bob", "Jones"}),
 				mustNewElement(tag.Rows, []int{128}),
 				mustNewElement(tag.FloatingPointValue, []float64{128.10}),
+				mustNewElement(tag.DimensionIndexPointer, []int{32, 36950}),
 			}},
 			expectedError: nil,
 		},


### PR DESCRIPTION
This addresses #143 by parsing elements with VR=AT as Ints (instead of the default fallback of parsing as strings).