### PR TITLE
write: Item VL should not default to UndefinedLength

### DIFF
--- a/write.go
+++ b/write.go
@@ -301,7 +301,7 @@ func writeVRVL(w dicomio.Writer, t tag.Tag, vr string, vl uint32) error {
 		vl = tag.VLUndefinedLength
 	}
 
-	if vr == "SQ" || t == tag.Item {
+	if vr == vrraw.Sequence {
 		// We are going to write these out with undefined length always.
 		vl = tag.VLUndefinedLength
 	}

--- a/write_test.go
+++ b/write_test.go
@@ -281,6 +281,29 @@ func TestWrite(t *testing.T) {
 			}},
 			expectedError: nil,
 		},
+		{
+			name: "encapsulated PixelData",
+			dataset: Dataset{Elements: []*Element{
+				mustNewElement(tag.MediaStorageSOPClassUID, []string{"1.2.840.10008.5.1.4.1.1.1.2"}),
+				mustNewElement(tag.MediaStorageSOPInstanceUID, []string{"1.2.3.4.5.6.7"}),
+				mustNewElement(tag.TransferSyntaxUID, []string{uid.ImplicitVRLittleEndian}),
+				mustNewElement(tag.Rows, []int{2}),
+				mustNewElement(tag.Columns, []int{2}),
+				mustNewElement(tag.BitsAllocated, []int{8}),
+				setUndefinedLength(mustNewElement(tag.PixelData, PixelDataInfo{
+					IsEncapsulated: true,
+					Frames: []frame.Frame{
+						{
+							Encapsulated:     true,
+							EncapsulatedData: frame.EncapsulatedFrame{Data: []byte{1, 2, 3, 4}},
+						},
+					},
+				})),
+				mustNewElement(tag.FloatingPointValue, []float64{128.10}),
+				mustNewElement(tag.DimensionIndexPointer, []int{32, 36950}),
+			}},
+			expectedError: nil,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -320,8 +343,8 @@ func TestWrite(t *testing.T) {
 				cmpOpts = append(cmpOpts, tc.cmpOpts...)
 
 				if diff := cmp.Diff(
-					readDS.Elements,
 					wantElems,
+					readDS.Elements,
 					cmpOpts...,
 				); diff != "" {
 					t.Errorf("Reading back written dataset led to unexpected diff from source data: %s", diff)
@@ -451,4 +474,9 @@ func TestWriteFloats(t *testing.T) {
 		})
 	}
 
+}
+
+func setUndefinedLength(e *Element) *Element {
+	e.ValueLength = tag.VLUndefinedLength
+	return e
 }

--- a/write_test.go
+++ b/write_test.go
@@ -287,8 +287,6 @@ func TestWrite(t *testing.T) {
 				mustNewElement(tag.MediaStorageSOPClassUID, []string{"1.2.840.10008.5.1.4.1.1.1.2"}),
 				mustNewElement(tag.MediaStorageSOPInstanceUID, []string{"1.2.3.4.5.6.7"}),
 				mustNewElement(tag.TransferSyntaxUID, []string{uid.ImplicitVRLittleEndian}),
-				mustNewElement(tag.Rows, []int{2}),
-				mustNewElement(tag.Columns, []int{2}),
 				mustNewElement(tag.BitsAllocated, []int{8}),
 				setUndefinedLength(mustNewElement(tag.PixelData, PixelDataInfo{
 					IsEncapsulated: true,
@@ -296,6 +294,31 @@ func TestWrite(t *testing.T) {
 						{
 							Encapsulated:     true,
 							EncapsulatedData: frame.EncapsulatedFrame{Data: []byte{1, 2, 3, 4}},
+						},
+					},
+				})),
+				mustNewElement(tag.FloatingPointValue, []float64{128.10}),
+				mustNewElement(tag.DimensionIndexPointer, []int{32, 36950}),
+			}},
+			expectedError: nil,
+		},
+		{
+			name: "encapsulated PixelData: multiframe",
+			dataset: Dataset{Elements: []*Element{
+				mustNewElement(tag.MediaStorageSOPClassUID, []string{"1.2.840.10008.5.1.4.1.1.1.2"}),
+				mustNewElement(tag.MediaStorageSOPInstanceUID, []string{"1.2.3.4.5.6.7"}),
+				mustNewElement(tag.TransferSyntaxUID, []string{uid.ImplicitVRLittleEndian}),
+				mustNewElement(tag.BitsAllocated, []int{8}),
+				setUndefinedLength(mustNewElement(tag.PixelData, PixelDataInfo{
+					IsEncapsulated: true,
+					Frames: []frame.Frame{
+						{
+							Encapsulated:     true,
+							EncapsulatedData: frame.EncapsulatedFrame{Data: []byte{1, 2, 3, 4}},
+						},
+						{
+							Encapsulated:     true,
+							EncapsulatedData: frame.EncapsulatedFrame{Data: []byte{1, 2, 3, 8}},
 						},
 					},
 				})),


### PR DESCRIPTION
I do not think that we should be writing out item VLs as undefined length by default. However, if the caller calls writeVRVL with an item and provides an undefined length VL, then that will be respected.

__Unlike other dicom sequences__, the encapsulated image sequence items cannot be written with undefined length. 

> The encapsulated pixel stream of encoded pixel data is segmented into one or more Fragments, __each of which conveys its own explicit length__. The sequence of Fragments of the encapsulated pixel stream is terminated by a delimiter, thus allowing the support of encoding processes where the resulting length of the entire pixel stream is not known until it is entirely encoded.

http://dicom.nema.org/dicom/2013/output/chtml/part05/sect_8.2.html

The effective change here is that all other sequence items will continue to be written out with undefined length VLs (and Item delimitation items), except for encapsulated image sequences. 