### PR TITLE
Introduce FlatStatefulIterator, and ExhaustElementChannel

### DIFF
--- a/dataset.go
+++ b/dataset.go
@@ -114,8 +114,12 @@ func flatElementsIterator(elems []*Element, elemChan chan<- *Element) {
 	}
 }
 
+// FlatDatasetIterator represents a simple iterator over the elements in a
+// Dataset.
 type FlatDatasetIterator interface {
+	// HasNext indicates if the iterator as another element.
 	HasNext() bool
+	// Next gets and returns the next element in the iterator.
 	Next() *Element
 }
 

--- a/dataset.go
+++ b/dataset.go
@@ -60,8 +60,8 @@ func (d *Dataset) FindElementByTagNested(tag tag.Tag) (*Element, error) {
 	return nil, ErrorElementNotFound
 }
 
-// FlatIterator returns a channel upon which every element in this Dataset will be sent,
-// including elements nested inside sequences.
+// FlatIterator returns a channel upon which every element in this Dataset will
+// be sent, including elements nested inside sequences.
 //
 // NOTE: If you don't need the channel API and don't want to worry about fully
 // exhausting the channel, use Dataset.FlatStatefulIterator instead.

--- a/dataset.go
+++ b/dataset.go
@@ -142,9 +142,10 @@ func (f *FlatDatasetIterator) Next() *Element {
 // are added or removed), those elements will not be included until a new
 // iterator is created.
 //
-// If you don't need to receive elements on a/ channel, and don't want to worry
+// If you don't need to receive elements on a channel, and don't want to worry
 // about always exhausting this iterator, this is the best and safest way to
-// iterate over a Dataset.
+// iterate over a Dataset. Unlike FlatIterator(), no special cleanup or channel
+// exhausting is needed with this iterator.
 func (d *Dataset) FlatStatefulIterator() *FlatDatasetIterator {
 	return &FlatDatasetIterator{flattenedDataset: flatSliceBuilder(d.Elements)}
 }

--- a/dataset.go
+++ b/dataset.go
@@ -60,6 +60,10 @@ func (d *Dataset) FindElementByTagNested(tag tag.Tag) (*Element, error) {
 	return nil, ErrorElementNotFound
 }
 
+// FlatIterator will be deprecated soon in favor of
+// Dataset.FlatStatefulIterator. Use FlatStatefulIterator instead of this,
+// unless the channel API really makes your life a lot easier.
+//
 // FlatIterator returns a channel upon which every element in this Dataset will
 // be sent, including elements nested inside sequences.
 //

--- a/dataset.go
+++ b/dataset.go
@@ -62,13 +62,11 @@ func (d *Dataset) FindElementByTagNested(tag tag.Tag) (*Element, error) {
 
 // FlatIterator will be deprecated soon in favor of
 // Dataset.FlatStatefulIterator. Use FlatStatefulIterator instead of this,
-// unless the channel API really makes your life a lot easier.
+// unless the channel API really makes your life a lot easier (and let the
+// maintainers know on GitHub).
 //
 // FlatIterator returns a channel upon which every element in this Dataset will
 // be sent, including elements nested inside sequences.
-//
-// NOTE: If you don't need the channel API and don't want to worry about fully
-// exhausting the channel, use Dataset.FlatStatefulIterator instead.
 //
 // If for some reason your code will not exhaust the iterator (read all
 // elements), be sure to call ExhaustElementChannel to prevent leaving the

--- a/dataset.go
+++ b/dataset.go
@@ -72,7 +72,8 @@ func (d *Dataset) FindElementByTagNested(tag tag.Tag) (*Element, error) {
 //  c := dataset.FlatIterator()
 //  defer ExhaustElementChannel(c)
 //  for elem := range c {
-//      // Even if you exit before reading everything in c (e.g. due to an error)
+//      // Even if you exit before reading everything in c (e.g. due to an
+//      // error)
 //      // things will be ok.
 //  }
 //

--- a/dataset.go
+++ b/dataset.go
@@ -62,6 +62,10 @@ func (d *Dataset) FindElementByTagNested(tag tag.Tag) (*Element, error) {
 
 // FlatIterator returns a channel upon which every element in this Dataset will be sent,
 // including elements nested inside sequences.
+//
+// NOTE: If you don't need the channel API and don't want to worry about fully
+// exhausting the channel, use Dataset.FlatStatefulIterator instead.
+//
 // If for some reason your code will not exhaust the iterator (read all
 // elements), be sure to call ExhaustElementChannel to prevent leaving the
 // underlying Goroutine alive (you can safely do this in a defer).
@@ -71,9 +75,6 @@ func (d *Dataset) FindElementByTagNested(tag tag.Tag) (*Element, error) {
 //      // Even if you exit before reading everything in c (e.g. due to an error)
 //      // things will be ok.
 //  }
-//
-// If you don't need the channel API and don't want to worry about fully
-// exhausting the channel, use Dataset.FlatStatefulIterator instead.
 //
 // Note that the sequence element itself is sent on the channel in addition to
 // the child elements in the sequence.

--- a/dataset.go
+++ b/dataset.go
@@ -120,14 +120,6 @@ type FlatDatasetIterator struct {
 	idx              int
 }
 
-type flatElemsWrapper struct {
-	flatElems []*Element
-}
-
-func (f *flatElemsWrapper) append(e *Element) {
-	f.flatElems = append(f.flatElems, e)
-}
-
 // HasNext indicates if the iterator as another element.
 func (f *FlatDatasetIterator) HasNext() bool {
 	return f.idx < len(f.flattenedDataset)

--- a/dataset_test.go
+++ b/dataset_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/suyashkumar/dicom/pkg/tag"
 )
 
@@ -53,6 +54,80 @@ func TestDataset_FindElementByTag(t *testing.T) {
 	}
 }
 
+func TestDataset_FlatStatefulIterator(t *testing.T) {
+	cases := []struct {
+		name                 string
+		dataset              Dataset
+		expectedFlatElements []*Element
+	}{
+		{
+			name: "flat dataset",
+			dataset: Dataset{Elements: []*Element{
+				mustNewElement(tag.PatientName, []string{"Bob", "Smith"}),
+				mustNewElement(tag.PatientName, []string{"Bob", "Jones"}),
+			}},
+			expectedFlatElements: []*Element{
+				mustNewElement(tag.PatientName, []string{"Bob", "Smith"}),
+				mustNewElement(tag.PatientName, []string{"Bob", "Jones"}),
+			},
+		},
+		{
+			name: "nested dataset",
+			dataset: Dataset{Elements: []*Element{
+				makeSequenceElement(tag.AddOtherSequence, [][]*Element{
+					// Item 1
+					{
+						mustNewElement(tag.PatientName, []string{"Bob", "Jones"}),
+						// Nested Sequence.
+						makeSequenceElement(tag.AnatomicRegionSequence, [][]*Element{
+							{
+								mustNewElement(tag.PatientName, []string{"Bob", "Smith"}),
+							},
+						}),
+					},
+				}),
+			}},
+			expectedFlatElements: []*Element{
+				// First, expect the entire SQ element
+				makeSequenceElement(tag.AddOtherSequence, [][]*Element{
+					// Item 1
+					{
+						mustNewElement(tag.PatientName, []string{"Bob", "Jones"}),
+						// Nested Sequence.
+						makeSequenceElement(tag.AnatomicRegionSequence, [][]*Element{
+							{
+								mustNewElement(tag.PatientName, []string{"Bob", "Smith"}),
+							},
+						}),
+					},
+				}),
+				// Then expect the inner elements
+				mustNewElement(tag.PatientName, []string{"Bob", "Jones"}),
+				// Inner SQ element
+				makeSequenceElement(tag.AnatomicRegionSequence, [][]*Element{
+					{
+						mustNewElement(tag.PatientName, []string{"Bob", "Smith"}),
+					},
+				}),
+				// Inner element of the inner SQ
+				mustNewElement(tag.PatientName, []string{"Bob", "Smith"}),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotElems []*Element
+			for iter := tc.dataset.FlatStatefulIterator(); iter.HasNext(); {
+				gotElems = append(gotElems, iter.Next())
+			}
+			if diff := cmp.Diff(tc.expectedFlatElements, gotElems, cmp.AllowUnexported(allValues...)); diff != "" {
+				t.Errorf("FlatStatefulIterator(%v) returned unexpected set of elements: %v", tc.dataset, diff)
+			}
+		})
+	}
+}
+
 func ExampleDataset_FlatIterator() {
 	nestedData := [][]*Element{
 		{
@@ -88,6 +163,52 @@ func ExampleDataset_FlatIterator() {
 
 	for elem := range data.FlatIterator() {
 		fmt.Println(elem.Tag)
+	}
+
+	// Note the output below includes all three leaf elements __as well as__ the sequence element's tag
+
+	// Unordered output:
+	// (0028,0010)
+	// (0028,0011)
+	// (0010,0010)
+	// (0046,0102)
+}
+
+func ExampleDataset_FlatStatefulIterator() {
+	nestedData := [][]*Element{
+		{
+			{
+				Tag:                 tag.PatientName,
+				ValueRepresentation: tag.VRString,
+				Value: &stringsValue{
+					value: []string{"Bob"},
+				},
+			},
+		},
+	}
+
+	data := Dataset{
+		Elements: []*Element{
+			{
+				Tag:                 tag.Rows,
+				ValueRepresentation: tag.VRInt32List,
+				Value: &intsValue{
+					value: []int{100},
+				},
+			},
+			{
+				Tag:                 tag.Columns,
+				ValueRepresentation: tag.VRInt32List,
+				Value: &intsValue{
+					value: []int{200},
+				},
+			},
+			makeSequenceElement(tag.AddOtherSequence, nestedData),
+		},
+	}
+
+	for iter := data.FlatStatefulIterator(); iter.HasNext(); {
+		fmt.Println(iter.Next().Tag)
 	}
 
 	// Note the output below includes all three leaf elements __as well as__ the sequence element's tag


### PR DESCRIPTION
This addresses the discussion in #183 by introducing a FlatStatefulIterator (that will be GC'd normally, even if it isn't exhausted). This also introduces ExhaustElementChannel which is an easy way for folks using the channel API to ensure it is always exhausted.

At some point either we should deprecate the channel-based API, or we should rename it so that it's not seen as the default for iteration (e.g. name it `FlatChannelIterator` or something). For most usecases, the stateful iterator should be sufficient.

Future improvements can we made to the stateful iterator, for example not recomputing the flat element representation if the dataset hasn't changed from a previous call. 