### PR TITLE
Refactor/Invert dcmtime.PrecisionLevel values for safe-by-default value creation

### DIFF
--- a/dataset.go
+++ b/dataset.go
@@ -99,7 +99,7 @@ func (d *Dataset) FlatIterator() <-chan *Element {
 // Or, if you don't need the channel interface, simply use
 // Dataset.FlatStatefulIterator.
 func ExhaustElementChannel(c <-chan *Element) {
-	for _ = range c {
+	for range c {
 	}
 }
 

--- a/pkg/dcmtime/common.go
+++ b/pkg/dcmtime/common.go
@@ -12,9 +12,9 @@ import (
 // value must be of equal or lesser precision.
 //
 // For instance, if `check` is PrecisionSeconds, then minutes, hours, days, months and
-// years would return true, but nanos would return false, since when printing a DT
-// value with a seconds precision, all of said values would be included in the rendered
-// DT value: '20210723121456' (YYYYMMDDHHMMSS).
+// years would return true, but milliseconds would return false, since when printing a
+// DT value with a seconds precision, all of said values would be included in the
+// rendered DT value: '20210723121456' (YYYYMMDDHHMMSS).
 //
 // Example: to test whether seconds should be included, you would:
 // isIncluded(PrecisionSeconds, [caller-passed-limit])

--- a/pkg/dcmtime/common.go
+++ b/pkg/dcmtime/common.go
@@ -13,14 +13,14 @@ import (
 // Example: to test whether seconds should be included, you would:
 // isIncluded(PrecisionSeconds, [caller-passed-limit])
 func isIncluded(check PrecisionLevel, precision PrecisionLevel) bool {
-	return check <= precision
+	return check >= precision
 }
 
 // truncateMilliseconds truncate nanosecond time.Time value to arbitrary precision.
 func truncateMilliseconds(nanoSeconds int, precision PrecisionLevel) (millis string) {
 	milliseconds := nanoSeconds / 1000
 	millis = fmt.Sprintf("%06d", milliseconds)
-	millis = millis[:6-(PrecisionFull-precision)]
+	millis = millis[:6-(PrecisionFull+precision)]
 
 	return millis
 }
@@ -69,7 +69,7 @@ func extractDurationInfo(subMatches []string, index int, isFractal bool) (durati
 		// get our nano-seconds.
 		missingPlaces := 9 - len(valueStr)
 		valueStr = valueStr + strings.Repeat("0", missingPlaces)
-		info.FractalPrecision = PrecisionFull - PrecisionLevel(missingPlaces-3)
+		info.FractalPrecision = PrecisionFull + PrecisionLevel(missingPlaces-3)
 	}
 
 	// If our info is present, parse the value into an int.

--- a/pkg/dcmtime/common.go
+++ b/pkg/dcmtime/common.go
@@ -8,12 +8,18 @@ import (
 	"time"
 )
 
-// isIncluded returns whether `check` is included in `limit`.
+// isIncluded returns whether `check` is included in `limit`. To be "included", the
+// value must be of equal or lesser precision.
+//
+// For instance, if `check` is PrecisionSeconds, then minutes, hours, days, months and
+// years would return true, but nanos would return false, since when printing a DT
+// value with a seconds precision, all of said values would be included in the rendered
+// DT value: '20210723121456' (YYYYMMDDHHMMSS).
 //
 // Example: to test whether seconds should be included, you would:
 // isIncluded(PrecisionSeconds, [caller-passed-limit])
-func isIncluded(check PrecisionLevel, precision PrecisionLevel) bool {
-	return check >= precision
+func isIncluded(check PrecisionLevel, limit PrecisionLevel) bool {
+	return check >= limit
 }
 
 // truncateMilliseconds truncate nanosecond time.Time value to arbitrary precision.

--- a/pkg/dcmtime/date_test.go
+++ b/pkg/dcmtime/date_test.go
@@ -200,3 +200,17 @@ func TestDate_DCMTrimming(t *testing.T) {
 		})
 	}
 }
+
+// TestDate_SaneDefaults tests that instantiating a new Date object with just the Time
+// field specified yields a reasonable result.
+func TestDate_SaneDefaults(t *testing.T) {
+	newValue := dcmtime.Date{
+		Time: time.Date(2021, 03, 16, 0, 0, 0, 0, time.FixedZone("", 0)),
+	}
+
+	dcmVal := newValue.DCM()
+	expexted := "20210316"
+	if dcmVal != expexted {
+		t.Errorf("DCM(): expected '%v', but got '%v'", expexted, dcmVal)
+	}
+}

--- a/pkg/dcmtime/datetime_test.go
+++ b/pkg/dcmtime/datetime_test.go
@@ -715,3 +715,17 @@ func TestDatetime_Methods(t *testing.T) {
 		})
 	}
 }
+
+// TestDatetime_SaneDefaults tests that instantiating a new Datetime object with just
+// the Time field specified yields a reasonable result.
+func TestDatetime_SaneDefaults(t *testing.T) {
+	newValue := dcmtime.Datetime{
+		Time: time.Date(2021, 03, 16, 13, 45, 32, 123456000, time.FixedZone("", 60)),
+	}
+
+	dcmVal := newValue.DCM()
+	expexted := "20210316134532.123456+0001"
+	if dcmVal != expexted {
+		t.Errorf("DCM(): expected '%v', but got '%v'", expexted, dcmVal)
+	}
+}

--- a/pkg/dcmtime/precision.go
+++ b/pkg/dcmtime/precision.go
@@ -45,37 +45,37 @@ func (level PrecisionLevel) String() string {
 }
 
 const (
-	// PrecisionYear indicated that a given dcm time value is only precise to the year.
-	PrecisionYear PrecisionLevel = iota
-	// PrecisionMonth indicated that a given dcm time value is only precise to the
-	// month.
-	PrecisionMonth
-	// PrecisionDay indicated that a given dcm time value is only precise to the day.
-	PrecisionDay
-	// PrecisionHours indicated that a given dcm time value is only precise to the hour.
-	PrecisionHours
-	// PrecisionMinutes indicated that a given dcm time value is only precise to the
-	// minute.
-	PrecisionMinutes
-	// PrecisionSeconds indicated that a given dcm time value is only precise to the
-	// second.
-	PrecisionSeconds
-	// PrecisionMS1 indicated that a given dcm time value is only precise to 1
-	// millisecond place (1/10 of a second).
-	PrecisionMS1
-	// PrecisionMS2 indicated that a given dcm time value is only precise to 2
-	// millisecond place (1/100 of a second).
-	PrecisionMS2
-	// PrecisionMS3 indicated that a given dcm time value is only precise to 3
-	// millisecond place (1/1000 of a second).
-	PrecisionMS3
-	// PrecisionMS4 indicated that a given dcm time value is only precise to 4
-	// millisecond place (1/10000 of a second).
-	PrecisionMS4
+	// PrecisionFull indicates that a given dcm time value is precise to the full extent
+	// it is able to be.
+	PrecisionFull PrecisionLevel = iota
 	// PrecisionMS5 indicated that a given dcm time value is only precise to 4
 	// millisecond place (1/100000 of a second).
 	PrecisionMS5
-	// PrecisionFull indicates that a given dcm time value is precise to the full extent
-	// it is able to be.
-	PrecisionFull
+	// PrecisionMS4 indicated that a given dcm time value is only precise to 4
+	// millisecond place (1/10000 of a second).
+	PrecisionMS4
+	// PrecisionMS3 indicated that a given dcm time value is only precise to 3
+	// millisecond place (1/1000 of a second).
+	PrecisionMS3
+	// PrecisionMS2 indicated that a given dcm time value is only precise to 2
+	// millisecond place (1/100 of a second).
+	PrecisionMS2
+	// PrecisionMS1 indicated that a given dcm time value is only precise to 1
+	// millisecond place (1/10 of a second).
+	PrecisionMS1
+	// PrecisionSeconds indicated that a given dcm time value is only precise to the
+	// second.
+	PrecisionSeconds
+	// PrecisionMinutes indicated that a given dcm time value is only precise to the
+	// minute.
+	PrecisionMinutes
+	// PrecisionHours indicated that a given dcm time value is only precise to the hour.
+	PrecisionHours
+	// PrecisionDay indicated that a given dcm time value is only precise to the day.
+	PrecisionDay
+	// PrecisionMonth indicated that a given dcm time value is only precise to the
+	// month.
+	PrecisionMonth
+	// PrecisionYear indicated that a given dcm time value is only precise to the year.
+	PrecisionYear
 )

--- a/pkg/dcmtime/time_test.go
+++ b/pkg/dcmtime/time_test.go
@@ -340,3 +340,17 @@ func TestTime_Methods(t *testing.T) {
 		})
 	}
 }
+
+// TestTime_SaneDefaults tests that instantiating a new Time object with just the Time
+// field specified yields a reasonable result.
+func TestTime_SaneDefaults(t *testing.T) {
+	newValue := dcmtime.Time{
+		Time: time.Date(1, 1, 1, 12, 7, 56, 123456000, time.FixedZone("", 0)),
+	}
+
+	dcmVal := newValue.DCM()
+	expected := "120756.123456"
+	if dcmVal != expected {
+		t.Errorf("DCM(): expected '%v', but got '%v'", expected, dcmVal)
+	}
+}


### PR DESCRIPTION
Just a quick refactor I want to get in to follow up on #171 

Currently, the zero-value of PrecisionLevel is PrecisionYear, and gets more precise as the integer increases.

This creates an environment where the default behavior is not really sane or expected when creating new Date, Time, or Datetime values.

This PR inverts the PrecisionLevel iota, so PrecisionFull is the default zero value.

Currently, when creating a new Date value with just a time, this happens:

```go
package main

import (
	"fmt"
	"github.com/suyashkumar/dicom/pkg/dcmtime"
	"time"
)

func main() {
	newDate := dcmtime.Date{
		Time: time.Date(2021, 03, 16, 0, 0, 0, 0, time.UTC),
	}

	fmt.Println("DCM:", newDate.DCM())

	// Output:
	// DCM: 2021
}

```

Only the year is printed, that's kind of surprising.

This PR changes the behavior to:

```go
package main

import (
	"fmt"
	"github.com/suyashkumar/dicom/pkg/dcmtime"
	"time"
)

func main() {
	newDate := dcmtime.Date{
		Time: time.Date(2021, 03, 16, 0, 0, 0, 0, time.UTC),
	}

	fmt.Println("DCM:", newDate.DCM())

	// Output:
	// DCM: 20210316
}
```

Where the entire date value is kept during serialization by default.