### PR TITLE
Fixes Write() Failure on SQ Element with SkipVRVerification() set

### DIFF
--- a/dataset.go
+++ b/dataset.go
@@ -99,7 +99,7 @@ func (d *Dataset) FlatIterator() <-chan *Element {
 // Or, if you don't need the channel interface, simply use
 // Dataset.FlatStatefulIterator.
 func ExhaustElementChannel(c <-chan *Element) {
-	for _ = range c {
+	for range c {
 	}
 }
 

--- a/write.go
+++ b/write.go
@@ -182,13 +182,12 @@ func writeFileHeader(w dicomio.Writer, ds *Dataset, metaElems []*Element, opts w
 
 func writeElement(w dicomio.Writer, elem *Element, opts writeOptSet) error {
 	vr := elem.RawValueRepresentation
-	if !opts.skipVRVerification {
-		var err error
-		vr, err = verifyVROrDefault(elem.Tag, elem.RawValueRepresentation)
-		if err != nil {
-			return err
-		}
+	var err error
+	vr, err = verifyVROrDefault(elem.Tag, elem.RawValueRepresentation, opts)
+	if err != nil {
+		return err
 	}
+
 	if !opts.skipValueTypeVerification && elem.Value != nil {
 		err := verifyValueType(elem.Tag, elem.Value, vr)
 		if err != nil {
@@ -212,7 +211,7 @@ func writeElement(w dicomio.Writer, elem *Element, opts writeOptSet) error {
 		}
 	}
 
-	err := encodeElementHeader(w, elem.Tag, vr, length)
+	err = encodeElementHeader(w, elem.Tag, vr, length)
 	if err != nil {
 		return err
 	}
@@ -240,7 +239,7 @@ func writeMetaElem(w dicomio.Writer, t tag.Tag, ds *Dataset, tagsUsed *map[tag.T
 	return nil
 }
 
-func verifyVROrDefault(t tag.Tag, vr string) (string, error) {
+func verifyVROrDefault(t tag.Tag, vr string, opts writeOptSet) (string, error) {
 	tagInfo, err := tag.Find(t)
 	if err != nil {
 		return vrraw.Unknown, nil
@@ -248,7 +247,9 @@ func verifyVROrDefault(t tag.Tag, vr string) (string, error) {
 	if vr == "" {
 		return tagInfo.VR, nil
 	}
-	if tagInfo.VR != vr {
+
+	// Only verify if the caller has not elected to skip it.
+	if !opts.skipVRVerification && tagInfo.VR != vr {
 		return "", fmt.Errorf("ERROR dicomio.veryifyElement: VR mismatch for tag %v. Element.VR=%v, but DICOM standard defines VR to be %v",
 			tag.DebugString(t), vr, tagInfo.VR)
 	}
@@ -306,7 +307,8 @@ func writeVRVL(w dicomio.Writer, t tag.Tag, vr string, vl uint32) error {
 		vl = tag.VLUndefinedLength
 	}
 
-	if len(vr) != 2 && vl != tag.VLUndefinedLength && t != tag.SequenceDelimitationItem {
+	// We want to make sure there is any VR unless this is a Sequence delimiter.
+	if len(vr) != 2 && vl != tag.VLUndefinedLength && t != tag.SequenceDelimitationItem && t != tag.ItemDelimitationItem {
 		return fmt.Errorf("ERROR dicomio.writeVRVL: Value Representation must be of length 2, e.g. 'UN'. For tag=%v, it was RawValueRepresentation=%v",
 			tag.DebugString(t), vr)
 	}

--- a/write_test.go
+++ b/write_test.go
@@ -98,6 +98,57 @@ func TestWrite(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			name: "sequence (2 Items with 2 values each) - skip vr verification",
+			dataset: Dataset{Elements: []*Element{
+				mustNewElement(tag.MediaStorageSOPClassUID, []string{"1.2.840.10008.5.1.4.1.1.1.2"}),
+				mustNewElement(tag.MediaStorageSOPInstanceUID, []string{"1.2.3.4.5.6.7"}),
+				mustNewElement(tag.TransferSyntaxUID, []string{uid.ImplicitVRLittleEndian}),
+				mustNewElement(tag.PatientName, []string{"Bob", "Jones"}),
+				makeSequenceElement(tag.AddOtherSequence, [][]*Element{
+					// Item 1.
+					{
+						{
+							Tag:                    tag.PatientName,
+							ValueRepresentation:    tag.VRStringList,
+							RawValueRepresentation: "PN",
+							Value: &stringsValue{
+								value: []string{"Bob", "Jones"},
+							},
+						},
+						{
+							Tag:                    tag.Rows,
+							ValueRepresentation:    tag.VRUInt16List,
+							RawValueRepresentation: "US",
+							Value: &intsValue{
+								value: []int{100},
+							},
+						},
+					},
+					// Item 2.
+					{
+						{
+							Tag:                    tag.PatientName,
+							ValueRepresentation:    tag.VRStringList,
+							RawValueRepresentation: "PN",
+							Value: &stringsValue{
+								value: []string{"Bob", "Jones"},
+							},
+						},
+						{
+							Tag:                    tag.Rows,
+							ValueRepresentation:    tag.VRUInt16List,
+							RawValueRepresentation: "US",
+							Value: &intsValue{
+								value: []int{100},
+							},
+						},
+					},
+				}),
+			}},
+			expectedError: nil,
+			opts:          []WriteOption{SkipVRVerification()},
+		},
+		{
 			name: "nested sequences",
 			dataset: Dataset{Elements: []*Element{
 				mustNewElement(tag.MediaStorageSOPClassUID, []string{"1.2.840.10008.5.1.4.1.1.1.2"}),
@@ -132,6 +183,43 @@ func TestWrite(t *testing.T) {
 				}),
 			}},
 			expectedError: nil,
+		},
+		{
+			name: "nested sequences - without VR verification",
+			dataset: Dataset{Elements: []*Element{
+				mustNewElement(tag.MediaStorageSOPClassUID, []string{"1.2.840.10008.5.1.4.1.1.1.2"}),
+				mustNewElement(tag.MediaStorageSOPInstanceUID, []string{"1.2.3.4.5.6.7"}),
+				mustNewElement(tag.TransferSyntaxUID, []string{uid.ImplicitVRLittleEndian}),
+				mustNewElement(tag.PatientName, []string{"Bob", "Jones"}),
+				makeSequenceElement(tag.AddOtherSequence, [][]*Element{
+					// Item 1.
+					{
+						{
+							Tag:                    tag.PatientName,
+							ValueRepresentation:    tag.VRStringList,
+							RawValueRepresentation: "PN",
+							Value: &stringsValue{
+								value: []string{"Bob", "Jones"},
+							},
+						},
+						// Nested Sequence.
+						makeSequenceElement(tag.AnatomicRegionSequence, [][]*Element{
+							{
+								{
+									Tag:                    tag.PatientName,
+									ValueRepresentation:    tag.VRStringList,
+									RawValueRepresentation: "PN",
+									Value: &stringsValue{
+										value: []string{"Bob", "Jones"},
+									},
+								},
+							},
+						}),
+					},
+				}),
+			}},
+			expectedError: nil,
+			opts:          []WriteOption{SkipVRVerification()},
 		},
 		{
 			name: "without transfer syntax",
@@ -412,7 +500,7 @@ func TestVerifyVR(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			vr, err := verifyVROrDefault(tc.tg, tc.inVR)
+			vr, err := verifyVROrDefault(tc.tg, tc.inVR, writeOptSet{})
 			if (err != nil && !tc.wantErr) || (err == nil && tc.wantErr) {
 				t.Errorf("verifyVROrDefault(%v, %v), got err: %v but want err: %v", tc.tg, tc.inVR, err, tc.wantErr)
 			}


### PR DESCRIPTION
Hello. This closes #191.

I've pushed the evaluation of `SkipVRVerification()` into `verifyVROrDefault()` so defaults will be returned even with `SkipVRVerification()` set.

I've also added a guard for VR checking in `writeVRVL()` for `tag.ItemDelimitationItem` like the one for `tag.SequenceDelimitationItem`.

Lastly, I've added two tests to guard against regressions. These tests failed before the changes were made.