### PR TITLE
Bug/Do not replace caller-supplied VRs with UN for unknown Tags

### DIFF
--- a/element.go
+++ b/element.go
@@ -149,6 +149,21 @@ func mustNewElement(t tag.Tag, data interface{}) *Element {
 	return elem
 }
 
+func mustNewPrivateElement(t tag.Tag, rawVR string, data interface{}) *Element {
+	value, err := NewValue(data)
+	if err != nil {
+		log.Panic(fmt.Errorf("error creating value: %w", err))
+	}
+
+	return &Element{
+		Tag:                    t,
+		ValueRepresentation:    tag.GetVRKind(t, rawVR),
+		RawValueRepresentation: rawVR,
+		ValueLength:            0,
+		Value:                  value,
+	}
+}
+
 // ValueType is a type that represents the type of a Value. It is an enumerated
 // set, and the set of values can be found below.
 type ValueType int

--- a/write.go
+++ b/write.go
@@ -266,9 +266,8 @@ func verifyVROrDefault(t tag.Tag, vr string, opts writeOptSet) (string, error) {
 		return tagInfo.VR, nil
 	}
 
-	// If we've made it this far it's because the caller want's VR verification and
-	// passed a non-blank VR, so we should verify it.
-	if tagInfo.VR != vr {
+	// Verify the VR on the way out if the caller wants it.
+	if !opts.skipVRVerification && tagInfo.VR != vr {
 		return "", fmt.Errorf("ERROR dicomio.veryifyElement: VR mismatch for tag %v. Element.VR=%v, but DICOM standard defines VR to be %v",
 			tag.DebugString(t), vr, tagInfo.VR)
 	}

--- a/write.go
+++ b/write.go
@@ -187,8 +187,7 @@ func writeElement(w dicomio.Writer, elem *Element, opts writeOptSet) error {
 	if err != nil {
 		return err
 	}
-
-	w.GetTransferSyntax()
+	
 	if !opts.skipValueTypeVerification && elem.Value != nil {
 		err := verifyValueType(elem.Tag, elem.Value, vr)
 		if err != nil {

--- a/write.go
+++ b/write.go
@@ -250,10 +250,10 @@ func verifyVROrDefault(t tag.Tag, vr string, opts writeOptSet) (string, error) {
 	// Otherwise, get our tag info.
 	tagInfo, err := tag.Find(t)
 	if err != nil {
-		// If we cannot find it and our VR is blank, we will use "UNKNOWN" Otherwise we
-		// will fallback to the caller's VR and trust that they know more
-		// about this tag than we do. This could be a private tag, or a tag from a newer
-		// version of the DICOM spec.
+		// If we cannot find information about the tag and our VR is blank, we will use
+		// "UN" (Unknown). Otherwise we will fallback to the caller's VR and trust that
+		// they know more about this tag than we do. This could be a private tag, or a
+		// tag from a newer version of the DICOM spec.
 		if vr == "" {
 			vr = vrraw.Unknown
 		}

--- a/write_test.go
+++ b/write_test.go
@@ -3,6 +3,7 @@ package dicom
 import (
 	"bytes"
 	"encoding/binary"
+	"github.com/suyashkumar/dicom/pkg/vrraw"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -44,6 +45,18 @@ func TestWrite(t *testing.T) {
 				mustNewElement(tag.Rows, []int{128}),
 				mustNewElement(tag.FloatingPointValue, []float64{128.10}),
 				mustNewElement(tag.DimensionIndexPointer, []int{32, 36950}),
+			}},
+			expectedError: nil,
+		},
+		{
+			name: "private tag",
+			dataset: Dataset{Elements: []*Element{
+				mustNewElement(tag.MediaStorageSOPClassUID, []string{"1.2.840.10008.5.1.4.1.1.1.2"}),
+				mustNewElement(tag.MediaStorageSOPInstanceUID, []string{"1.2.3.4.5.6.7"}),
+				// We need to use an Explicit transfer syntax here or all data will be
+				// read in with "UN".
+				mustNewElement(tag.TransferSyntaxUID, []string{uid.ExplicitVRLittleEndian}),
+				mustNewPrivateElement(tag.Tag{0x0003, 0x0010}, vrraw.ShortText, []string{"some data"}),
 			}},
 			expectedError: nil,
 		},
@@ -472,6 +485,7 @@ func TestVerifyVR(t *testing.T) {
 		inVR    string
 		wantVR  string
 		wantErr bool
+		opts    writeOptSet
 	}{
 		{
 			name:    "wrong vr",
@@ -497,10 +511,30 @@ func TestVerifyVR(t *testing.T) {
 			wantVR:  "UN",
 			wantErr: false,
 		},
+		{
+			name: "private element",
+			tg: tag.Tag{
+				Group:   0x0003,
+				Element: 0x0010,
+			},
+			inVR:    "DA",
+			wantVR:  "DA",
+			wantErr: false,
+		},
+		{
+			name:    "skip validation - wrong vr",
+			tg:      tag.PatientName,
+			inVR:    "DS",
+			wantVR:  "DS",
+			wantErr: false,
+			opts: writeOptSet{
+				skipVRVerification: true,
+			},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			vr, err := verifyVROrDefault(tc.tg, tc.inVR, writeOptSet{})
+			vr, err := verifyVROrDefault(tc.tg, tc.inVR, tc.opts)
 			if (err != nil && !tc.wantErr) || (err == nil && tc.wantErr) {
 				t.Errorf("verifyVROrDefault(%v, %v), got err: %v but want err: %v", tc.tg, tc.inVR, err, tc.wantErr)
 			}


### PR DESCRIPTION
Hello!

This PR closes #193 .

This PR changes the behavior of the writer to default to any existing VR value when we do not have any information on the tag, effectively trusting that the caller knows more than we do about this element. I've added a couple tests to verify this is working as intended, and I've also refactored the logic a bit in `verifyVROrDefault` and added some code comments explaining the intent of certain logic paths.