### PR TITLE
Feature/add ValueCount() method to Value

### DIFF
--- a/element.go
+++ b/element.go
@@ -70,10 +70,19 @@ type Value interface {
 	// ValueType returns the underlying ValueType of this Value. This can be used to unpack the underlying data in this
 	// Value.
 	ValueType() ValueType
+	// ValueCount returns the number of inner values that GetValue() will return.
+	//
+	// For instance: a Value that contains []int{1, 2} would return a ValueCount() of 2.
+	//
+	// []byte values will always return 1 and PixelData values will return the number of
+	// frames they contain.
+	ValueCount() int
 	// GetValue returns the underlying value that this Value holds. What type is returned here can be determined exactly
 	// from the ValueType() of this Value (see the ValueType godoc).
 	GetValue() interface{} // TODO: rename to Get to read cleaner
+	// String implements fmt.Stringer
 	String() string
+	// MarshalJSON implements json.Marshaler
 	MarshalJSON() ([]byte, error)
 }
 
@@ -181,6 +190,7 @@ type bytesValue struct {
 
 func (b *bytesValue) isElementValue()       {}
 func (b *bytesValue) ValueType() ValueType  { return Bytes }
+func (b *bytesValue) ValueCount() int       { return 1 }
 func (b *bytesValue) GetValue() interface{} { return b.value }
 func (b *bytesValue) String() string {
 	return fmt.Sprintf("%v", b.value)
@@ -196,6 +206,7 @@ type stringsValue struct {
 
 func (s *stringsValue) isElementValue()       {}
 func (s *stringsValue) ValueType() ValueType  { return Strings }
+func (s *stringsValue) ValueCount() int       { return len(s.value) }
 func (s *stringsValue) GetValue() interface{} { return s.value }
 func (s *stringsValue) String() string {
 	return fmt.Sprintf("%v", s.value)
@@ -211,6 +222,7 @@ type intsValue struct {
 
 func (s *intsValue) isElementValue()       {}
 func (s *intsValue) ValueType() ValueType  { return Ints }
+func (s *intsValue) ValueCount() int       { return len(s.value) }
 func (s *intsValue) GetValue() interface{} { return s.value }
 func (s *intsValue) String() string {
 	return fmt.Sprintf("%v", s.value)
@@ -226,6 +238,7 @@ type floatsValue struct {
 
 func (s *floatsValue) isElementValue()       {}
 func (s *floatsValue) ValueType() ValueType  { return Floats }
+func (s *floatsValue) ValueCount() int       { return len(s.value) }
 func (s *floatsValue) GetValue() interface{} { return s.value }
 func (s *floatsValue) String() string {
 	return fmt.Sprintf("%v", s.value)
@@ -246,6 +259,8 @@ func (s *SequenceItemValue) isElementValue() {}
 // ValueType returns the underlying ValueType of this Value. This can be used
 // to unpack the underlying data in this Value.
 func (s *SequenceItemValue) ValueType() ValueType { return SequenceItem }
+
+func (s *SequenceItemValue) ValueCount() int { return len(s.elements) }
 
 // GetValue returns the underlying value that this Value holds. What type is
 // returned here can be determined exactly from the ValueType() of this Value
@@ -270,6 +285,7 @@ type sequencesValue struct {
 
 func (s *sequencesValue) isElementValue()       {}
 func (s *sequencesValue) ValueType() ValueType  { return Sequences }
+func (s *sequencesValue) ValueCount() int       { return len(s.value) }
 func (s *sequencesValue) GetValue() interface{} { return s.value }
 func (s *sequencesValue) String() string {
 	// TODO: consider adding more sophisticated formatting
@@ -293,6 +309,7 @@ type pixelDataValue struct {
 
 func (e *pixelDataValue) isElementValue()       {}
 func (e *pixelDataValue) ValueType() ValueType  { return PixelData }
+func (e *pixelDataValue) ValueCount() int       { return len(e.PixelDataInfo.Frames) }
 func (e *pixelDataValue) GetValue() interface{} { return e.PixelDataInfo }
 func (e *pixelDataValue) String() string {
 	// TODO: consider adding more sophisticated formatting

--- a/element_test.go
+++ b/element_test.go
@@ -63,23 +63,27 @@ func TestNewValue(t *testing.T) {
 		name      string
 		data      interface{}
 		wantValue Value
+		wantCount int
 		wantError error
 	}{
 		{
 			name:      "strings",
 			data:      []string{"a", "b"},
 			wantValue: &stringsValue{value: []string{"a", "b"}},
+			wantCount: 2,
 			wantError: nil,
 		},
 		{
 			name:      "floats",
 			data:      []float64{1.11, 1.22},
+			wantCount: 2,
 			wantValue: &floatsValue{value: []float64{1.11, 1.22}},
 			wantError: nil,
 		},
 		{
 			name:      "ints",
 			data:      []int{1, 2},
+			wantCount: 2,
 			wantValue: &intsValue{value: []int{1, 2}},
 			wantError: nil,
 		},
@@ -87,6 +91,7 @@ func TestNewValue(t *testing.T) {
 			name:      "bytes",
 			data:      []byte{0x00, 0x01},
 			wantValue: &bytesValue{value: []byte{0x00, 0x01}},
+			wantCount: 1,
 			wantError: nil,
 		},
 		{
@@ -94,6 +99,7 @@ func TestNewValue(t *testing.T) {
 			name:      "PixelDataInfo",
 			data:      PixelDataInfo{IsEncapsulated: true},
 			wantValue: &pixelDataValue{PixelDataInfo{IsEncapsulated: true}},
+			wantCount: 0,
 			wantError: nil,
 		},
 		{
@@ -122,6 +128,7 @@ func TestNewValue(t *testing.T) {
 					},
 				},
 			}},
+			wantCount: 1,
 		},
 	}
 	for _, tc := range cases {
@@ -132,6 +139,9 @@ func TestNewValue(t *testing.T) {
 			}
 			if diff := cmp.Diff(v, tc.wantValue, cmp.AllowUnexported(allValues...)); diff != "" {
 				t.Errorf("NewValue(%v) unexpected value. diff: %v", tc.data, diff)
+			}
+			if v.ValueCount() != tc.wantCount {
+				t.Errorf("Value.ValueCount() expected count %v, got %v", tc.wantCount, v.ValueCount())
 			}
 		})
 	}


### PR DESCRIPTION
Hello again!

In writing some code, I realized it would be useful to get the number of inner values a Value contains without having to do a type assert (or really knowing anything about the inner type).

This is a small PR that adds a `ValueCount() int` method to `Value`.

Example:

```go
package main

import (
	"fmt"
	"github.com/suyashkumar/dicom"
	"github.com/suyashkumar/dicom/pkg/tag"
)

func main() {
	element, err := dicom.NewElement(tag.ModalitiesInStudy, []string{"MR", "CT"})
	if err != nil {
		panic(err)
	}

	tagInfo, err := tag.Find(tag.ModalitiesInStudy)
	if err != nil {
		panic(err)
	}

	fmt.Println("TAG        :", element.Tag)
	fmt.Println("VM         :", tagInfo.VM)
	fmt.Println("VALUE COUNT:", element.Value.ValueCount())

	// Output:
	// TAG        : (0008,0061)
	// VM         : 1-n
	// VALUE COUNT: 2
}
```

I've opened this as a draft PR in case you feel it doesn't fit the lib. Let me know what you think!