### PR TITLE
Feature/Value.IsZero method

### DIFF
--- a/pkg/personname/groupInfo_test.go
+++ b/pkg/personname/groupInfo_test.go
@@ -83,7 +83,7 @@ func TestNewPersonNameFromDicom(t *testing.T) {
 		Raw string
 		// The parsed information we expect.
 		Expected GroupInfo
-		// Whether IsZero should return true after parsing Raw.
+		// Whether IsEmpty should return true after parsing Raw.
 		IsEmpty bool
 	}{
 		// Full Name
@@ -351,7 +351,7 @@ func TestNewPersonNameFromDicom(t *testing.T) {
 			}
 		})
 
-		// Test .IsZero() method.
+		// Test .IsEmpty() method.
 		t.Run(tc.Raw+"_IsEmpty", func(t *testing.T) {
 			parsed, err := groupFromValueString(tc.Raw, pnGroupAlphabetic)
 			if err != nil {
@@ -360,7 +360,7 @@ func TestNewPersonNameFromDicom(t *testing.T) {
 
 			if tc.IsEmpty != parsed.IsEmpty() {
 				t.Errorf(
-					".IsZero() returned %v, extected %v",
+					".IsEmpty() returned %v, extected %v",
 					parsed.IsEmpty(),
 					tc.IsEmpty,
 				)

--- a/pkg/personname/info_test.go
+++ b/pkg/personname/info_test.go
@@ -11,7 +11,7 @@ func TestInfo(t *testing.T) {
 		Raw string
 		// The parsed information we expect.
 		Expected Info
-		// Whether IsZero should return true after parsing Raw.
+		// Whether IsEmpty should return true after parsing Raw.
 		IsEmpty bool
 	}{
 		// All groups
@@ -371,7 +371,7 @@ func TestInfo(t *testing.T) {
 			)
 		})
 
-		// Test the .IsZero() method.
+		// Test the .IsEmpty() method.
 		t.Run(tc.Raw+"_isEmpty", func(t *testing.T) {
 			newInfo, err := Parse(tc.Raw)
 			if err != nil {
@@ -381,7 +381,7 @@ func TestInfo(t *testing.T) {
 
 			if tc.IsEmpty != newInfo.IsEmpty() {
 				t.Errorf(
-					".IsZero(): got '%v', expected '%v'",
+					".IsEmpty(): got '%v', expected '%v'",
 					tc.IsEmpty,
 					newInfo.IsEmpty(),
 				)


### PR DESCRIPTION
Hello!

Opening this as a draft in case you feel it does not belong in the lib.

When extracting information from Dicom Element values, I often find it necessary to make sure that a value is not "empty" or "zero"; that is that the value provided is an actual value.

A few examples would be a PatientName value of "", a Rows or Columns value of 0, or a OB element with no actual bytes present.

This PR adds an IsZero() method to value that checks if the inner value is actually a zero-value.

Example Usage:

```go
var patientName string
if element.Value.IsZero() {
	patientName = "[UNKNOWN]"
} else {
	patientName = element.Value.GetValue().([]string)[0]
}
```

This PR will likely have merge conflicts with #195 . If you end up liking both of them, feel free to merge either one, then I can update the other to resolve any merge conflicts that occur.

Thanks!

As a side note: a lot of these PRs are groundwork I am using for a value decoder helper-type I am using internally. If you would be interested in seeing what I am tinkering on there, I could open a draft PR with it, as I think it might make a nice addition to the lib. Let me know!