### PR TITLE
Set capacity, not length, for bytes buffer allocation

### DIFF
--- a/read.go
+++ b/read.go
@@ -368,8 +368,10 @@ func readBytes(r dicomio.Reader, t tag.Tag, vr string, vl uint32) (Value, error)
 		if vl%2 != 0 {
 			return nil, ErrorOWRequiresEvenVL
 		}
-		data := make([]byte, vl)
-		buf := bytes.NewBuffer(data)
+
+		// Buffers append to the end of their internal slice, so make sure our starting
+		// buffer has a length of 0 and a *capacity* of the value length.
+		buf := bytes.NewBuffer(make([]byte, 0, vl))
 		numWords := int(vl / 2)
 		for i := 0; i < numWords; i++ {
 			word, err := r.ReadUInt16()

--- a/read.go
+++ b/read.go
@@ -368,9 +368,7 @@ func readBytes(r dicomio.Reader, t tag.Tag, vr string, vl uint32) (Value, error)
 		if vl%2 != 0 {
 			return nil, ErrorOWRequiresEvenVL
 		}
-
-		// Buffers append to the end of their internal slice, so make sure our starting
-		// buffer has a length of 0 and a *capacity* of the value length.
+		
 		buf := bytes.NewBuffer(make([]byte, 0, vl))
 		numWords := int(vl / 2)
 		for i := 0; i < numWords; i++ {

--- a/write_test.go
+++ b/write_test.go
@@ -601,7 +601,6 @@ func TestWriteOtherWord(t *testing.T) {
 			name:  "OtherWord",
 			value: []byte{0x1, 0x2, 0x3, 0x4},
 			vr:    "OW",
-			// TODO: improve test expectation
 			expectedData: []byte{0x1, 0x2, 0x3, 0x4},
 			expectedErr:  nil,
 		},
@@ -609,7 +608,6 @@ func TestWriteOtherWord(t *testing.T) {
 			name:  "OtherBytes",
 			value: []byte{0x1, 0x2, 0x3, 0x4},
 			vr:    "OB",
-			// TODO: improve test expectation
 			expectedData: []byte{0x1, 0x2, 0x3, 0x4},
 			expectedErr:  nil,
 		},

--- a/write_test.go
+++ b/write_test.go
@@ -44,6 +44,7 @@ func TestWrite(t *testing.T) {
 				mustNewElement(tag.Rows, []int{128}),
 				mustNewElement(tag.FloatingPointValue, []float64{128.10}),
 				mustNewElement(tag.DimensionIndexPointer, []int{32, 36950}),
+				mustNewElement(tag.RedPaletteColorLookupTableData, []byte{0x1, 0x2, 0x3, 0x4}),
 			}},
 			expectedError: nil,
 		},
@@ -580,6 +581,49 @@ func TestWriteFloats(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.expectedData, buf.Bytes()); diff != "" {
 				t.Errorf("writeFloats(%v, %s) wrote unexpected data. diff: %s", tc.value, tc.vr, diff)
+				t.Errorf("% x", buf.Bytes())
+			}
+		})
+	}
+
+}
+
+func TestWriteOtherWord(t *testing.T) {
+	// TODO: add additional cases
+	cases := []struct {
+		name         string
+		value        []byte
+		vr           string
+		expectedData []byte
+		expectedErr  error
+	}{
+		{
+			name:  "OtherWord",
+			value: []byte{0x1, 0x2, 0x3, 0x4},
+			vr:    "OW",
+			// TODO: improve test expectation
+			expectedData: []byte{0x1, 0x2, 0x3, 0x4},
+			expectedErr:  nil,
+		},
+		{
+			name:  "OtherBytes",
+			value: []byte{0x1, 0x2, 0x3, 0x4},
+			vr:    "OB",
+			// TODO: improve test expectation
+			expectedData: []byte{0x1, 0x2, 0x3, 0x4},
+			expectedErr:  nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := bytes.Buffer{}
+			w := dicomio.NewWriter(&buf, binary.LittleEndian, false)
+			err := writeBytes(w, tc.value, tc.vr)
+			if err != tc.expectedErr {
+				t.Errorf("writeBytes(%v, %s) returned unexpected err. got: %v, want: %v", tc.value, tc.vr, err, tc.expectedErr)
+			}
+			if diff := cmp.Diff(tc.expectedData, buf.Bytes()); diff != "" {
+				t.Errorf("writeBytes(%v, %s) wrote unexpected data. diff: %s", tc.value, tc.vr, diff)
 				t.Errorf("% x", buf.Bytes())
 			}
 		})


### PR DESCRIPTION
Closes #199 via fix laid out in the issue.

I've added a couple tests to confirm correctness of the read/write.