### PR TITLE
Export writeElement and readElement

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -158,7 +158,7 @@ func (p *Parser) Next() (*Element, error) {
 		}
 		return nil, ErrorEndOfDICOM
 	}
-	elem, err := readElement(p.reader, &p.dataset, p.frameChannel)
+	elem, err := ReadElement(p.reader, &p.dataset, p.frameChannel)
 	if err != nil {
 		// TODO: tolerate some kinds of errors and continue parsing
 		return nil, err
@@ -209,7 +209,7 @@ func (p *Parser) readHeader() ([]*Element, error) {
 
 	// Must read metadata as LittleEndian explicit VR
 	// Read the length of the metadata elements: (0002,0000) MetaElementGroupLength
-	maybeMetaLen, err := readElement(p.reader, nil, nil)
+	maybeMetaLen, err := ReadElement(p.reader, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +229,7 @@ func (p *Parser) readHeader() ([]*Element, error) {
 	}
 	defer p.reader.PopLimit()
 	for !p.reader.IsLimitExhausted() {
-		elem, err := readElement(p.reader, nil, nil)
+		elem, err := ReadElement(p.reader, nil, nil)
 		if err != nil {
 			// TODO: see if we can skip over malformed elements somehow
 			return nil, err

--- a/read.go
+++ b/read.go
@@ -272,7 +272,7 @@ func readSequence(r dicomio.Reader, t tag.Tag, vr string, vl uint32) (Value, err
 
 	if vl == tag.VLUndefinedLength {
 		for {
-			subElement, err := readElement(r, nil, nil)
+			subElement, err := ReadElement(r, nil, nil)
 			if err != nil {
 				// Stop reading due to error
 				log.Println("error reading subitem, ", err)
@@ -299,7 +299,7 @@ func readSequence(r dicomio.Reader, t tag.Tag, vr string, vl uint32) (Value, err
 			return nil, err
 		}
 		for !r.IsLimitExhausted() {
-			subElement, err := readElement(r, nil, nil)
+			subElement, err := ReadElement(r, nil, nil)
 			if err != nil {
 				// TODO: option to ignore errors parsing subelements?
 				return nil, err
@@ -325,7 +325,7 @@ func readSequenceItem(r dicomio.Reader, t tag.Tag, vr string, vl uint32) (Value,
 
 	if vl == tag.VLUndefinedLength {
 		for {
-			subElem, err := readElement(r, &seqElements, nil)
+			subElem, err := ReadElement(r, &seqElements, nil)
 			if err != nil {
 				return nil, err
 			}
@@ -343,7 +343,7 @@ func readSequenceItem(r dicomio.Reader, t tag.Tag, vr string, vl uint32) (Value,
 		}
 
 		for !r.IsLimitExhausted() {
-			subElem, err := readElement(r, &seqElements, nil)
+			subElem, err := ReadElement(r, &seqElements, nil)
 			if err != nil {
 				return nil, err
 			}
@@ -368,7 +368,7 @@ func readBytes(r dicomio.Reader, t tag.Tag, vr string, vl uint32) (Value, error)
 		if vl%2 != 0 {
 			return nil, ErrorOWRequiresEvenVL
 		}
-		
+
 		buf := bytes.NewBuffer(make([]byte, 0, vl))
 		numWords := int(vl / 2)
 		for i := 0; i < numWords; i++ {
@@ -500,12 +500,12 @@ func readInt(r dicomio.Reader, t tag.Tag, vr string, vl uint32) (Value, error) {
 	return retVal, err
 }
 
-// readElement reads the next element. If the next element is a sequence element,
+// ReadElement reads the next element. If the next element is a sequence element,
 // it may result in a collection of Elements. It takes a pointer to the Dataset of
 // elements read so far, since previously read elements may be needed to parse
 // certain Elements (like native PixelData). If the Dataset is nil, it is
 // treated as an empty Dataset.
-func readElement(r dicomio.Reader, d *Dataset, fc chan<- *frame.Frame) (*Element, error) {
+func ReadElement(r dicomio.Reader, d *Dataset, fc chan<- *frame.Frame) (*Element, error) {
 	t, err := readTag(r)
 	if err != nil {
 		return nil, err
@@ -527,7 +527,7 @@ func readElement(r dicomio.Reader, d *Dataset, fc chan<- *frame.Frame) (*Element
 		return nil, err
 	}
 
-	// log.Println("readElement: vr, vl", vr, vl)
+	// log.Println("ReadElement: vr, vl", vr, vl)
 
 	val, err := readValue(r, *t, vr, vl, readImplicit, d, fc)
 	if err != nil {


### PR DESCRIPTION
I'm working on a port of the [grailbio/go-netdicom](https://github.com/grailbio/go-netdicom) package to use your maintained and more idiomatic implementation instead of [grailbio/go-dicom](https://github.com/grailbio/go-dicom). To be able to encode and decode DIMSE messages, I need to use per-element writing and reading. Rather than reimplementing this functionality myself, I propose exporting the readElement and writeElement functions so that go-netdicom or other packages that require low-level DICOM functionality may benefit.