### PR TITLE
Add initial build tag based debug logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ build:
 build-fast:
 	go build -o build/${BINARY} ./cmd/dicomutil
 
+.PHONY: build-debug
+build-debug:
+	go build -tags debug -o build/${BINARY} ./cmd/dicomutil
+
 .PHONY: test
 test:
 	go test ./... -v

--- a/parse.go
+++ b/parse.go
@@ -29,6 +29,7 @@ import (
 	"os"
 
 	"github.com/suyashkumar/dicom/pkg/charset"
+	"github.com/suyashkumar/dicom/pkg/debug"
 	"github.com/suyashkumar/dicom/pkg/dicomio"
 	"github.com/suyashkumar/dicom/pkg/frame"
 	"github.com/suyashkumar/dicom/pkg/tag"
@@ -119,10 +120,12 @@ func NewParser(in io.Reader, bytesToRead int64, frameChannel chan *frame.Frame) 
 		frameChannel: frameChannel,
 	}
 
+	debug.Log("NewParser: readHeader")
 	elems, err := p.readHeader()
 	if err != nil {
 		return nil, err
 	}
+	debug.Log("NewParser: readHeader complete")
 
 	p.dataset = Dataset{Elements: elems}
 	// TODO(suyashkumar): avoid storing the metadata pointers twice (though not that expensive)

--- a/pkg/debug/debug.go
+++ b/pkg/debug/debug.go
@@ -1,0 +1,15 @@
+// +build debug
+
+package debug
+
+import "log"
+
+// Log only logs when the debug build flag is present.
+func Log(data string) {
+	log.Println(data)
+}
+
+// Logf only logs with a formatted string when the debug build flag is present.
+func Logf(format string, args ...interface{}) {
+	log.Printf(format, args...)
+}

--- a/pkg/debug/default.go
+++ b/pkg/debug/default.go
@@ -1,0 +1,9 @@
+// +build !debug
+
+package debug
+
+// Log only logs when the debug build flag is present.
+func Log(data string) {}
+
+// Logf only logs with a formatted string when the debug build flag is present.
+func Logf(format string, args ...interface{}) {}

--- a/read.go
+++ b/read.go
@@ -24,12 +24,8 @@ var (
 	// value length which is not allowed.
 	ErrorOWRequiresEvenVL = errors.New("vr of OW requires even value length")
 	// ErrorUnsupportedVR indicates that this VR is not supported.
-	ErrorUnsupportedVR = errors.New("unsupported VR")
-	// ErrorUnsupportedBitsAllocated indicates that the BitsAllocated in the
-	// NativeFrame PixelData is unsupported. In this situation, the rest of the
-	// dataset returned is still valid.
-	ErrorUnsupportedBitsAllocated = errors.New("unsupported BitsAllocated")
-	errorUnableToParseFloat       = errors.New("unable to parse float type")
+	ErrorUnsupportedVR      = errors.New("unsupported VR")
+	errorUnableToParseFloat = errors.New("unable to parse float type")
 )
 
 func readTag(r dicomio.Reader) (*tag.Tag, error) {


### PR DESCRIPTION
This adds in initial build-tag based debug logging instrumentation. If this library is in a binary build with `-tags debug`, the debug statements will be active and log data. Otherwise, the debug logs will be no-ops. 

This stats to address #78.