### PR TITLE
Interpret "" DICOM Character Set as iso-8859-1

### DIFF
--- a/pkg/charset/charset.go
+++ b/pkg/charset/charset.go
@@ -40,6 +40,7 @@ const (
 // htmlEncodingNames represents a mapping of DICOM charset name to golang encoding/htmlindex name.  "" means
 // 7bit ascii.
 var htmlEncodingNames = map[string]string{
+	"":                "iso-8859-1",
 	"ISO_IR 6":        "iso-8859-1",
 	"ISO 2022 IR 6":   "iso-8859-1",
 	"ISO_IR 13":       "shift_jis",


### PR DESCRIPTION
Fix #218 
If there are spaces in a particular character set, they are interpreted in the same way as IR6. (Strictly speaking, this accepts data that violates the standard, but it can interpret data that meets the standard.) 