### PR TITLE
Treat Unknown Tags with defined VL as OW

### DIFF
--- a/pkg/tag/tag.go
+++ b/pkg/tag/tag.go
@@ -128,7 +128,7 @@ func GetVRKind(tag Tag, vr string) VRKind {
 		return VRDate
 	case "AT":
 		return VRTagList
-	case "OW", "OB":
+	case "OW", "OB", "UN":
 		return VRBytes
 	case "LT", "UT":
 		return VRString

--- a/read.go
+++ b/read.go
@@ -422,7 +422,7 @@ func readSequenceItem(r dicomio.Reader, t tag.Tag, vr string, vl uint32) (Value,
 
 func readBytes(r dicomio.Reader, t tag.Tag, vr string, vl uint32) (Value, error) {
 	// TODO: add special handling of PixelData
-	if vr == vrraw.OtherByte {
+	if vr == vrraw.OtherByte || vr == vrraw.Unknown {
 		data := make([]byte, vl)
 		_, err := io.ReadFull(r, data)
 		return &bytesValue{value: data}, err
@@ -466,7 +466,6 @@ func readString(r dicomio.Reader, t tag.Tag, vr string, vl uint32) (Value, error
 
 	// Split multiple strings
 	strs := strings.Split(str, "\\")
-
 	return &stringsValue{value: strs}, err
 }
 

--- a/read_test.go
+++ b/read_test.go
@@ -168,9 +168,16 @@ func TestReadOWBytes(t *testing.T) {
 		expectedErr error
 	}{
 		{
-			name:        "even-number bytes",
+			name:        "OW VR with even-number bytes",
 			bytes:       []byte{0x1, 0x2, 0x3, 0x4},
 			VR:          vrraw.OtherWord,
+			want:        &bytesValue{value: []byte{0x1, 0x2, 0x3, 0x4}},
+			expectedErr: nil,
+		},
+		{
+			name:        "UN VR even-number bytes",
+			bytes:       []byte{0x1, 0x2, 0x3, 0x4},
+			VR:          vrraw.Unknown,
 			want:        &bytesValue{value: []byte{0x1, 0x2, 0x3, 0x4}},
 			expectedErr: nil,
 		},

--- a/write.go
+++ b/write.go
@@ -210,6 +210,7 @@ func writeFileHeader(w dicomio.Writer, ds *Dataset, metaElems []*Element, opts w
 }
 
 func writeElement(w dicomio.Writer, elem *Element, opts writeOptSet) error {
+	fmt.Println("WRITE ELEMENT ", elem.Tag)
 	vr := elem.RawValueRepresentation
 	var err error
 	vr, err = verifyVROrDefault(elem.Tag, elem.RawValueRepresentation, opts)
@@ -220,9 +221,12 @@ func writeElement(w dicomio.Writer, elem *Element, opts writeOptSet) error {
 	if !opts.skipValueTypeVerification && elem.Value != nil {
 		err := verifyValueType(elem.Tag, elem.Value, vr)
 		if err != nil {
+			fmt.Println("return")
 			return err
 		}
 	}
+
+	fmt.Println("after verify")
 
 	length := elem.ValueLength
 	var valueData = &bytes.Buffer{}
@@ -323,6 +327,7 @@ func verifyValueType(t tag.Tag, value Value, vr string) error {
 		ok = valueType == Floats
 	default:
 		ok = valueType == Strings
+		fmt.Println(valueType)
 	}
 
 	if !ok {
@@ -457,6 +462,7 @@ func writeValue(w dicomio.Writer, t tag.Tag, value Value, valueType ValueType, v
 }
 
 func writeStrings(w dicomio.Writer, values []string, vr string) error {
+	fmt.Println("WRITE STR ", values)
 	s := ""
 	for i, substr := range values {
 		if i > 0 {
@@ -510,6 +516,7 @@ func writeInts(w dicomio.Writer, values []int, vr string) error {
 				return err
 			}
 		case vrraw.UnsignedLong, vrraw.SignedLong:
+			fmt.Println("WRITE: ", value)
 			if err := w.WriteUInt32(uint32(value)); err != nil {
 				return err
 			}

--- a/write_test.go
+++ b/write_test.go
@@ -58,8 +58,18 @@ func TestWrite(t *testing.T) {
 						value: []string{"1234"},
 					},
 				},
+				{
+					Tag:                    tag.Tag{0x0019, 0x1027},
+					ValueRepresentation:    tag.VRInt32List,
+					RawValueRepresentation: "SL",
+					ValueLength:            4,
+					Value: &intsValue{
+						value: []int{100},
+					},
+				},
 			}},
 			expectedError: nil,
+			opts:          []WriteOption{SkipValueTypeVerification(), SkipVRVerification()},
 		},
 		{
 			name: "private tag",

--- a/write_test.go
+++ b/write_test.go
@@ -3,7 +3,6 @@ package dicom
 import (
 	"bytes"
 	"encoding/binary"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -49,27 +48,18 @@ func TestWrite(t *testing.T) {
 				mustNewElement(tag.DimensionIndexPointer, []int{32, 36950}),
 				mustNewElement(tag.RedPaletteColorLookupTableData, []byte{0x1, 0x2, 0x3, 0x4}),
 				mustNewElement(tag.SelectorSLValue, []int{-20}),
-				{
-					Tag:                    tag.Tag{0x0019, 0x1026},
-					ValueRepresentation:    tag.VRStringList,
-					RawValueRepresentation: "UN",
-					ValueLength:            4,
-					Value: &stringsValue{
-						value: []string{"1234"},
-					},
-				},
+				// Some tag with an unknown VR.
 				{
 					Tag:                    tag.Tag{0x0019, 0x1027},
-					ValueRepresentation:    tag.VRInt32List,
-					RawValueRepresentation: "SL",
+					ValueRepresentation:    tag.VRBytes,
+					RawValueRepresentation: "UN",
 					ValueLength:            4,
-					Value: &intsValue{
-						value: []int{100},
+					Value: &bytesValue{
+						value: []byte{0x1, 0x2, 0x3, 0x4},
 					},
 				},
 			}},
 			expectedError: nil,
-			opts:          []WriteOption{SkipValueTypeVerification(), SkipVRVerification()},
 		},
 		{
 			name: "private tag",
@@ -488,8 +478,6 @@ func TestWrite(t *testing.T) {
 					cmpopts.SortSlices(func(x, y *Element) bool { return x.Tag.Compare(y.Tag) == 1 }),
 				}
 				cmpOpts = append(cmpOpts, tc.cmpOpts...)
-
-				fmt.Println(readDS.Elements)
 
 				if diff := cmp.Diff(
 					wantElems,

--- a/write_test.go
+++ b/write_test.go
@@ -3,6 +3,7 @@ package dicom
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -47,6 +48,16 @@ func TestWrite(t *testing.T) {
 				mustNewElement(tag.FloatingPointValue, []float64{128.10}),
 				mustNewElement(tag.DimensionIndexPointer, []int{32, 36950}),
 				mustNewElement(tag.RedPaletteColorLookupTableData, []byte{0x1, 0x2, 0x3, 0x4}),
+				mustNewElement(tag.SelectorSLValue, []int{-20}),
+				{
+					Tag:                    tag.Tag{0x0019, 0x1026},
+					ValueRepresentation:    tag.VRStringList,
+					RawValueRepresentation: "UN",
+					ValueLength:            4,
+					Value: &stringsValue{
+						value: []string{"1234"},
+					},
+				},
 			}},
 			expectedError: nil,
 		},
@@ -467,6 +478,8 @@ func TestWrite(t *testing.T) {
 					cmpopts.SortSlices(func(x, y *Element) bool { return x.Tag.Compare(y.Tag) == 1 }),
 				}
 				cmpOpts = append(cmpOpts, tc.cmpOpts...)
+
+				fmt.Println(readDS.Elements)
 
 				if diff := cmp.Diff(
 					wantElems,


### PR DESCRIPTION
This change ensures that unknown tags with a defined VL are read as bytes (OW). This should fix #231. Previously they would have been read as strings by default. 