### PR TITLE
fix issue with odd number of pixel bytes

### DIFF
--- a/read.go
+++ b/read.go
@@ -30,7 +30,7 @@ var (
 	// dataset returned is still valid.
 	ErrorUnsupportedBitsAllocated = errors.New("unsupported BitsAllocated")
 	errorUnableToParseFloat       = errors.New("unable to parse float type")
-	ErrorDoesNotConformToDICOM    = errors.New("field length is not even, in violation of DICOM spec")
+	ErrorExpectedEvenLength    = errors.New("field length is not even, in violation of DICOM spec")
 )
 
 func readTag(r dicomio.Reader) (*tag.Tag, error) {

--- a/read.go
+++ b/read.go
@@ -323,7 +323,7 @@ func readNativeFrames(d dicomio.Reader, parsedData *Dataset, fc chan<- *frame.Fr
 	}
 
 	bytesRead = bytesAllocated * samplesPerPixel * pixelsPerFrame * nFrames
-	if uint32(bytesRead) == vl-1 {
+	if vl > 0 && uint32(bytesRead) == vl-1 {
 		if vl%2 != 0 {
 			// this error should never happen if the file conforms to the DICOM spec
 			return nil, bytesRead, fmt.Errorf("odd number of bytes specified for PixelData violates DICOM spec: %d", vl)

--- a/read.go
+++ b/read.go
@@ -30,7 +30,7 @@ var (
 	// dataset returned is still valid.
 	ErrorUnsupportedBitsAllocated = errors.New("unsupported BitsAllocated")
 	errorUnableToParseFloat       = errors.New("unable to parse float type")
-	ErrorExpectedEvenLength    = errors.New("field length is not even, in violation of DICOM spec")
+	ErrorExpectedEvenLength       = errors.New("field length is not even, in violation of DICOM spec")
 )
 
 func readTag(r dicomio.Reader) (*tag.Tag, error) {

--- a/read.go
+++ b/read.go
@@ -30,6 +30,7 @@ var (
 	// dataset returned is still valid.
 	ErrorUnsupportedBitsAllocated = errors.New("unsupported BitsAllocated")
 	errorUnableToParseFloat       = errors.New("unable to parse float type")
+	ErrorDoesNotConformToDICOM    = errors.New("field length is not even, in violation of DICOM spec")
 )
 
 func readTag(r dicomio.Reader) (*tag.Tag, error) {
@@ -326,7 +327,7 @@ func readNativeFrames(d dicomio.Reader, parsedData *Dataset, fc chan<- *frame.Fr
 	if vl > 0 && uint32(bytesRead) == vl-1 {
 		if vl%2 != 0 {
 			// this error should never happen if the file conforms to the DICOM spec
-			return nil, bytesRead, fmt.Errorf("odd number of bytes specified for PixelData violates DICOM spec: %d", vl)
+			return nil, bytesRead, fmt.Errorf("odd number of bytes specified for PixelData violates DICOM spec: %d : %w", vl, ErrorDoesNotConformToDICOM)
 		}
 		err := d.Skip(1)
 		if err != nil {

--- a/read.go
+++ b/read.go
@@ -166,7 +166,7 @@ func readPixelData(r dicomio.Reader, t tag.Tag, vr string, vl uint32, d *Dataset
 		return nil, errors.New("the Dataset context cannot be nil in order to read Native PixelData")
 	}
 
-	i, _, err := readNativeFrames(r, d, fc)
+	i, _, err := readNativeFrames(r, d, fc, vl)
 
 	if err != nil {
 		return nil, err
@@ -222,7 +222,7 @@ func fillBufferSingleBitAllocated(pixelData []int, d dicomio.Reader, bo binary.B
 
 // readNativeFrames reads NativeData frames from a Decoder based on already parsed pixel information
 // that should be available in parsedData (elements like NumberOfFrames, rows, columns, etc)
-func readNativeFrames(d dicomio.Reader, parsedData *Dataset, fc chan<- *frame.Frame) (pixelData *PixelDataInfo,
+func readNativeFrames(d dicomio.Reader, parsedData *Dataset, fc chan<- *frame.Frame, vl uint32) (pixelData *PixelDataInfo,
 	bytesRead int, err error) {
 	image := PixelDataInfo{
 		IsEncapsulated: false,
@@ -323,7 +323,17 @@ func readNativeFrames(d dicomio.Reader, parsedData *Dataset, fc chan<- *frame.Fr
 	}
 
 	bytesRead = bytesAllocated * samplesPerPixel * pixelsPerFrame * nFrames
-
+	if uint32(bytesRead) == vl-1 {
+		if vl%2 != 0 {
+			// this error should never happen if the file conforms to the DICOM spec
+			return nil, bytesRead, fmt.Errorf("odd number of bytes specified for PixelData violates DICOM spec: %d", vl)
+		}
+		err := d.Skip(1)
+		if err != nil {
+			return nil, bytesRead, fmt.Errorf("could not read padding byte: %w", err)
+		}
+		bytesRead++
+	}
 	return &image, bytesRead, nil
 }
 

--- a/read.go
+++ b/read.go
@@ -327,7 +327,7 @@ func readNativeFrames(d dicomio.Reader, parsedData *Dataset, fc chan<- *frame.Fr
 	if vl > 0 && uint32(bytesRead) == vl-1 {
 		if vl%2 != 0 {
 			// this error should never happen if the file conforms to the DICOM spec
-			return nil, bytesRead, fmt.Errorf("odd number of bytes specified for PixelData violates DICOM spec: %d : %w", vl, ErrorDoesNotConformToDICOM)
+			return nil, bytesRead, fmt.Errorf("odd number of bytes specified for PixelData violates DICOM spec: %d : %w", vl, ErrorExpectedEvenLength)
 		}
 		err := d.Skip(1)
 		if err != nil {

--- a/read_test.go
+++ b/read_test.go
@@ -367,7 +367,7 @@ func TestReadNativeFrames(t *testing.T) {
 			expectedError:     ErrorUnsupportedBitsAllocated,
 		},
 		{
-			Name: "3x3, 3 frames, 1 samples/pixel",
+			Name: "3x3, 3 frames, 1 samples/pixel, data bytes with padded 0",
 			existingData: Dataset{Elements: []*Element{
 				mustNewElement(tag.Rows, []int{3}),
 				mustNewElement(tag.Columns, []int{3}),

--- a/read_test.go
+++ b/read_test.go
@@ -486,7 +486,6 @@ func TestReadNativeFrames(t *testing.T) {
 				}
 			} else {
 				// writing 2 bytes (uint16) at a time
-
 				expectedBytes = len(tc.data) * 2
 				for _, item := range tc.data {
 					if err := binary.Write(&dcmdata, binary.LittleEndian, item); err != nil {

--- a/read_test.go
+++ b/read_test.go
@@ -467,7 +467,7 @@ func TestReadNativeFrames(t *testing.T) {
 			dataBytes:         []byte{1, 2, 3, 1, 2, 3},
 			expectedPixelData: nil,
 			pixelLength:       7,
-			expectedError:     ErrorDoesNotConformToDICOM,
+			expectedError:     ErrorExpectedEvenLength,
 		},
 	}
 

--- a/read_test.go
+++ b/read_test.go
@@ -477,7 +477,7 @@ func TestReadNativeFrames(t *testing.T) {
 			var expectedBytes int
 
 			if len(tc.data) == 0 {
-				// writing byte-by-bte
+				// writing byte-by-byte
 				expectedBytes = len(tc.dataBytes)
 				for _, item := range tc.dataBytes {
 					if err := binary.Write(&dcmdata, binary.LittleEndian, item); err != nil {

--- a/read_test.go
+++ b/read_test.go
@@ -221,7 +221,7 @@ func TestReadNativeFrames(t *testing.T) {
 		dataBytes         []byte
 		expectedPixelData *PixelDataInfo
 		expectedError     error
-		pixelLength       uint32
+		pixelVLOverride   uint32
 	}{
 		{
 			Name: "5x5, 1 frame, 1 samples/pixel",
@@ -466,7 +466,7 @@ func TestReadNativeFrames(t *testing.T) {
 			}},
 			dataBytes:         []byte{1, 2, 3, 1, 2, 3},
 			expectedPixelData: nil,
-			pixelLength:       7,
+			pixelVLOverride:   7,
 			expectedError:     ErrorExpectedEvenLength,
 		},
 	}
@@ -500,8 +500,8 @@ func TestReadNativeFrames(t *testing.T) {
 			}
 
 			var vl uint32
-			if tc.pixelLength > 0 {
-				vl = tc.pixelLength
+			if tc.pixelVLOverride > 0 {
+				vl = tc.pixelVLOverride
 			} else {
 				vl = uint32(dcmdata.Len())
 			}

--- a/read_test.go
+++ b/read_test.go
@@ -478,7 +478,6 @@ func TestReadNativeFrames(t *testing.T) {
 
 			if len(tc.data) == 0 {
 				// writing byte-by-bte
-
 				expectedBytes = len(tc.dataBytes)
 				for _, item := range tc.dataBytes {
 					if err := binary.Write(&dcmdata, binary.LittleEndian, item); err != nil {

--- a/read_test.go
+++ b/read_test.go
@@ -412,7 +412,7 @@ func TestReadNativeFrames(t *testing.T) {
 			expectedError: nil,
 		},
 		{
-			Name: "1x1, 3 frames, 3 samples/pixel",
+			Name: "1x1, 3 frames, 3 samples/pixel, data bytes with padded 0",
 			existingData: Dataset{Elements: []*Element{
 				mustNewElement(tag.Rows, []int{1}),
 				mustNewElement(tag.Columns, []int{1}),


### PR DESCRIPTION
There have been several issues that mention EOF errors. (e.g. #62)  This PR fixes an error that manifested itself with an EOF error, so it may address those.

The problem occurs when there is an odd number of bytes in the pixel data, and even though the value length is even, the parser doesn't count the last padding byte. 

Regarding the implementation, it might be more robust to skip ahead the difference between `vl` and `bytesRead` in `readNativeFrames`, but my understanding of this library and the DICOM standard is that the difference will always be 0 or 1.