### PR TITLE
Handle unknowns completely

### DIFF
--- a/dataset_test.go
+++ b/dataset_test.go
@@ -8,13 +8,13 @@ import (
 	"github.com/suyashkumar/dicom/pkg/tag"
 )
 
-func makeSequenceElement(tg tag.Tag, items [][]*Element) *Element {
+func makeSequenceElement(tg tag.Tag, items [][]*Element, unknown bool) *Element {
 	sequenceItems := make([]*SequenceItemValue, 0, len(items))
 	for _, item := range items {
 		sequenceItems = append(sequenceItems, &SequenceItemValue{elements: item})
 	}
 
-	return &Element{
+	e := &Element{
 		Tag:                    tg,
 		ValueRepresentation:    tag.VRSequence,
 		RawValueRepresentation: "SQ",
@@ -22,6 +22,14 @@ func makeSequenceElement(tg tag.Tag, items [][]*Element) *Element {
 			value: sequenceItems,
 		},
 	}
+
+	if unknown {
+		e.ValueRepresentation = tag.VRUnknown
+		e.RawValueRepresentation = "UN"
+		e.ValueLength = tag.VLUndefinedLength
+	}
+
+	return e
 }
 
 func TestDataset_FindElementByTag(t *testing.T) {
@@ -83,9 +91,9 @@ func TestDataset_FlatStatefulIterator(t *testing.T) {
 							{
 								mustNewElement(tag.PatientName, []string{"Bob", "Smith"}),
 							},
-						}),
+						}, false),
 					},
-				}),
+				}, false),
 			}},
 			expectedFlatElements: []*Element{
 				// First, expect the entire SQ element
@@ -98,9 +106,9 @@ func TestDataset_FlatStatefulIterator(t *testing.T) {
 							{
 								mustNewElement(tag.PatientName, []string{"Bob", "Smith"}),
 							},
-						}),
+						}, false),
 					},
-				}),
+				}, false),
 				// Then expect the inner elements
 				mustNewElement(tag.PatientName, []string{"Bob", "Jones"}),
 				// Inner SQ element
@@ -108,7 +116,7 @@ func TestDataset_FlatStatefulIterator(t *testing.T) {
 					{
 						mustNewElement(tag.PatientName, []string{"Bob", "Smith"}),
 					},
-				}),
+				}, false),
 				// Inner element of the inner SQ
 				mustNewElement(tag.PatientName, []string{"Bob", "Smith"}),
 			},
@@ -139,7 +147,7 @@ func ExampleDataset_FlatIterator() {
 		Elements: []*Element{
 			mustNewElement(tag.Rows, []int{100}),
 			mustNewElement(tag.Columns, []int{100}),
-			makeSequenceElement(tag.AddOtherSequence, nestedData),
+			makeSequenceElement(tag.AddOtherSequence, nestedData, false),
 		},
 	}
 
@@ -172,7 +180,7 @@ func ExampleDataset_FlatIteratorWithExhaustAllElements() {
 		Elements: []*Element{
 			mustNewElement(tag.Rows, []int{100}),
 			mustNewElement(tag.Columns, []int{100}),
-			makeSequenceElement(tag.AddOtherSequence, nestedData),
+			makeSequenceElement(tag.AddOtherSequence, nestedData, false),
 		},
 	}
 
@@ -220,7 +228,7 @@ func ExampleDataset_FlatStatefulIterator() {
 					value: []int{200},
 				},
 			},
-			makeSequenceElement(tag.AddOtherSequence, nestedData),
+			makeSequenceElement(tag.AddOtherSequence, nestedData, false),
 		},
 	}
 

--- a/element_test.go
+++ b/element_test.go
@@ -21,7 +21,7 @@ func TestElement_MarshalJSON_NestedElements(t *testing.T) {
 			},
 		},
 	}
-	seqElement := makeSequenceElement(tag.AddOtherSequence, nestedData)
+	seqElement := makeSequenceElement(tag.AddOtherSequence, nestedData, false)
 
 	want := `{"tag":{"Group":70,"Element":258},"VR":9,"rawVR":"SQ","valueLength":0,"value":[[{"tag":{"Group":16,"Element":16},"VR":2,"rawVR":"","valueLength":0,"value":["Bob"]}]]}`
 

--- a/parse.go
+++ b/parse.go
@@ -25,7 +25,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
-	"log"
 	"os"
 
 	"github.com/suyashkumar/dicom/pkg/charset"
@@ -109,7 +108,8 @@ type Parser struct {
 //
 // frameChannel is an optional channel (can be nil) upon which DICOM image frames will be sent as they are parsed (if
 // provided).
-func NewParser(in io.Reader, bytesToRead int64, frameChannel chan *frame.Frame) (*Parser, error) {
+func NewParser(in io.Reader, bytesToRead int64, frameChannel chan *frame.Frame, opts ...ParseOption) (*Parser, error) {
+	optSet := toParseOptSet(opts...)
 	reader, err := dicomio.NewReader(bufio.NewReader(in), binary.LittleEndian, bytesToRead)
 	if err != nil {
 		return nil, err
@@ -120,12 +120,16 @@ func NewParser(in io.Reader, bytesToRead int64, frameChannel chan *frame.Frame) 
 		frameChannel: frameChannel,
 	}
 
-	debug.Log("NewParser: readHeader")
-	elems, err := p.readHeader()
-	if err != nil {
-		return nil, err
+	elems := []*Element{}
+
+	if !optSet.skipMetadataReadOnNewParserInit {
+		debug.Log("NewParser: readHeader")
+		elems, err = p.readHeader()
+		if err != nil {
+			return nil, err
+		}
+		debug.Log("NewParser: readHeader complete")
 	}
-	debug.Log("NewParser: readHeader complete")
 
 	p.dataset = Dataset{Elements: elems}
 	// TODO(suyashkumar): avoid storing the metadata pointers twice (though not that expensive)
@@ -138,13 +142,13 @@ func NewParser(in io.Reader, bytesToRead int64, frameChannel chan *frame.Frame) 
 
 	ts, err := p.dataset.FindElementByTag(tag.TransferSyntaxUID)
 	if err != nil {
-		log.Println("WARN: could not find transfer syntax uid in metadata, proceeding with little endian implicit")
+		debug.Log("WARN: could not find transfer syntax uid in metadata, proceeding with little endian implicit")
 	} else {
 		bo, implicit, err = uid.ParseTransferSyntaxUID(MustGetStrings(ts.Value)[0])
 		if err != nil {
 			// TODO(suyashkumar): should we attempt to parse with LittleEndian
 			// Implicit here?
-			log.Println("WARN: could not parse transfer syntax uid in metadata")
+			debug.Log("WARN: could not parse transfer syntax uid in metadata")
 		}
 	}
 	p.reader.SetTransferSyntax(bo, implicit)
@@ -189,6 +193,11 @@ func (p *Parser) Next() (*Element, error) {
 // so far.
 func (p *Parser) GetMetadata() Dataset {
 	return p.metadata
+}
+
+// SetTransferSyntax sets the transfer syntax for the underlying dicomio.Reader.
+func (p *Parser) SetTransferSyntax(bo binary.ByteOrder, implicit bool) {
+	p.reader.SetTransferSyntax(bo, implicit)
 }
 
 // readHeader reads the DICOM magic header and group two metadata elements.
@@ -241,4 +250,28 @@ func (p *Parser) readHeader() ([]*Element, error) {
 		metaElems = append(metaElems, elem)
 	}
 	return metaElems, nil
+}
+
+// ParseOption represents an option that can be passed to NewParser.
+type ParseOption func(*parseOptSet)
+
+// parseOptSet represents the flattened option set after all ParseOptions have been applied.
+type parseOptSet struct {
+	skipMetadataReadOnNewParserInit bool
+}
+
+func toParseOptSet(opts ...ParseOption) *parseOptSet {
+	optSet := &parseOptSet{}
+	for _, opt := range opts {
+		opt(optSet)
+	}
+	return optSet
+}
+
+// SkipMetadataReadOnNewParserInit makes NewParser skip trying to parse metadata. This will make the Parser default to implicit little endian byte order.
+// Any metatata tags found in the dataset will still be available when parsing.
+func SkipMetadataReadOnNewParserInit() ParseOption {
+	return func(set *parseOptSet) {
+		set.skipMetadataReadOnNewParserInit = true
+	}
 }

--- a/parse_test.go
+++ b/parse_test.go
@@ -45,6 +45,30 @@ func TestParse(t *testing.T) {
 	}
 }
 
+// TestNewParserSkipMetadataReadOnNewParserInit tests that NewParser with the SkipMetadataReadOnNewParserInit option
+// parses the specified dataset but not its header metadata.
+func TestNewParserSkipMetadataReadOnNewParserInit(t *testing.T) {
+	fStat, err := os.Stat("./testdata/1.dcm")
+	if err != nil {
+		t.Fatalf("Unable to stat %s. Error: %v", fStat.Name(), err)
+	}
+
+	f, err := os.Open("./testdata/1.dcm")
+	if err != nil {
+		t.Fatalf("Unable to open %s. Error: %v", f.Name(), err)
+	}
+
+	p, err := dicom.NewParser(f, fStat.Size(), nil, dicom.SkipMetadataReadOnNewParserInit())
+	if err != nil {
+		t.Fatalf("dicom.Parse(%s) unexpected error: %v", f.Name(), err)
+	}
+
+	metadata := p.GetMetadata()
+	if len(metadata.Elements) > 0 {
+		t.Fatalf("Found %d metadata elements despite SkipMetadataReadOnNewParserInit()", len(metadata.Elements))
+	}
+}
+
 // BenchmarkParse runs sanity benchmarks over the sample files in testdata.
 func BenchmarkParse(b *testing.B) {
 	files, err := ioutil.ReadDir("./testdata")

--- a/pkg/charset/charset.go
+++ b/pkg/charset/charset.go
@@ -40,6 +40,7 @@ const (
 // htmlEncodingNames represents a mapping of DICOM charset name to golang encoding/htmlindex name.  "" means
 // 7bit ascii.
 var htmlEncodingNames = map[string]string{
+	"":                "iso-8859-1",
 	"ISO_IR 6":        "iso-8859-1",
 	"ISO 2022 IR 6":   "iso-8859-1",
 	"ISO_IR 13":       "shift_jis",

--- a/pkg/tag/tag.go
+++ b/pkg/tag/tag.go
@@ -128,7 +128,7 @@ func GetVRKind(tag Tag, vr string) VRKind {
 		return VRDate
 	case "AT":
 		return VRTagList
-	case "OW", "OB":
+	case "OW", "OB", "UN":
 		return VRBytes
 	case "LT", "UT":
 		return VRString

--- a/pkg/tag/tag.go
+++ b/pkg/tag/tag.go
@@ -131,7 +131,7 @@ func GetVRKind(tag Tag, vr string) VRKind {
 		return VRDate
 	case "AT":
 		return VRTagList
-	case "OW", "OB", "UN":
+	case "OW", "OB":
 		return VRBytes
 	case "LT", "UT":
 		return VRString

--- a/pkg/tag/tag.go
+++ b/pkg/tag/tag.go
@@ -114,6 +114,9 @@ const (
 	VRDate
 	// VRPixelData means the element stores a PixelDataInfo
 	VRPixelData
+	// VRUnknown means the VR of the element is unknown (possibly a private
+	// element seen while reading DICOMs in implicit transfer syntax).
+	VRUnknown
 )
 
 // GetVRKind returns the golang value encoding of an element with <tag, vr>.
@@ -146,6 +149,8 @@ func GetVRKind(tag Tag, vr string) VRKind {
 		return VRFloat64List
 	case "SQ":
 		return VRSequence
+	case "UN":
+		return VRUnknown
 	default:
 		return VRStringList
 	}

--- a/read.go
+++ b/read.go
@@ -422,7 +422,7 @@ func readSequenceItem(r dicomio.Reader, t tag.Tag, vr string, vl uint32) (Value,
 
 func readBytes(r dicomio.Reader, t tag.Tag, vr string, vl uint32) (Value, error) {
 	// TODO: add special handling of PixelData
-	if vr == vrraw.OtherByte {
+	if vr == vrraw.OtherByte || vr == vrraw.Unknown {
 		data := make([]byte, vl)
 		_, err := io.ReadFull(r, data)
 		return &bytesValue{value: data}, err
@@ -466,7 +466,6 @@ func readString(r dicomio.Reader, t tag.Tag, vr string, vl uint32) (Value, error
 
 	// Split multiple strings
 	strs := strings.Split(str, "\\")
-
 	return &stringsValue{value: strs}, err
 }
 

--- a/read.go
+++ b/read.go
@@ -108,6 +108,14 @@ func readValue(r dicomio.Reader, t tag.Tag, vr string, vl uint32, isImplicit boo
 		return readDate(r, t, vr, vl)
 	case tag.VRUInt16List, tag.VRUInt32List, tag.VRInt16List, tag.VRInt32List, tag.VRTagList:
 		return readInt(r, t, vr, vl)
+	// We read Unknown VRs as SQ VRs by default. More details on why can be
+	// found at https://github.com/suyashkumar/dicom/issues/220. It remains
+	// to be seen if this fits most DICOMs we see in the wild.
+	case tag.VRUnknown:
+		if isImplicit && vl == tag.VLUndefinedLength {
+			return readSequence(r, t, vr, vl)
+		}
+		return readString(r, t, vr, vl)
 	case tag.VRSequence:
 		return readSequence(r, t, vr, vl)
 	case tag.VRItem:

--- a/read.go
+++ b/read.go
@@ -111,6 +111,9 @@ func readValue(r dicomio.Reader, t tag.Tag, vr string, vl uint32, isImplicit boo
 	// We read Unknown VRs as SQ VRs by default. More details on why can be
 	// found at https://github.com/suyashkumar/dicom/issues/220. It remains
 	// to be seen if this fits most DICOMs we see in the wild.
+	// TODO(suyashkumar): consider replacing UN VRs with SQ earlier on if they
+	// meet this criteria, so users of the Dataset can interact with it
+	// correctly.
 	case tag.VRUnknown:
 		if isImplicit && vl == tag.VLUndefinedLength {
 			return readSequence(r, t, vr, vl)

--- a/read_test.go
+++ b/read_test.go
@@ -168,9 +168,16 @@ func TestReadOWBytes(t *testing.T) {
 		expectedErr error
 	}{
 		{
-			name:        "even-number bytes",
+			name:        "OW VR with even-number bytes",
 			bytes:       []byte{0x1, 0x2, 0x3, 0x4},
 			VR:          vrraw.OtherWord,
+			want:        &bytesValue{value: []byte{0x1, 0x2, 0x3, 0x4}},
+			expectedErr: nil,
+		},
+		{
+			name:        "UN VR even-number bytes",
+			bytes:       []byte{0x1, 0x2, 0x3, 0x4},
+			VR:          vrraw.Unknown,
 			want:        &bytesValue{value: []byte{0x1, 0x2, 0x3, 0x4}},
 			expectedErr: nil,
 		},

--- a/write.go
+++ b/write.go
@@ -313,7 +313,7 @@ func verifyValueType(t tag.Tag, value Value, vr string) error {
 		ok = valueType == Sequences
 	case "NA":
 		ok = valueType == SequenceItem
-	case vrraw.OtherWord, vrraw.OtherByte:
+	case vrraw.OtherWord, vrraw.OtherByte, vrraw.Unknown:
 		if t == tag.PixelData {
 			ok = valueType == PixelData
 		} else {
@@ -488,7 +488,7 @@ func writeStrings(w dicomio.Writer, values []string, vr string) error {
 func writeBytes(w dicomio.Writer, values []byte, vr string) error {
 	var err error
 	switch vr {
-	case vrraw.OtherWord:
+	case vrraw.OtherWord, vrraw.Unknown:
 		err = writeOtherWordString(w, values)
 	case vrraw.OtherByte:
 		err = writeOtherByteString(w, values)

--- a/write.go
+++ b/write.go
@@ -28,13 +28,30 @@ var (
 	ErrorUnsupportedBitsPerSample = errors.New("unsupported BitsPerSample value")
 )
 
-// TODO(suyashkumar): consider adding an element-by-element write API.
+// Writer is a struct that allows element-by element writing to a DICOM writer.
+type Writer struct {
+	writer dicomio.Writer
+	optSet *writeOptSet
+}
 
-// Write will write the input DICOM dataset to the provided io.Writer as a complete DICOM (including any header
-// information if available).
-func Write(out io.Writer, ds Dataset, opts ...WriteOption) error {
-	optSet := toOptSet(opts...)
+// NewWriter returns a new Writer, that points to the provided io.Writer.
+func NewWriter(out io.Writer, opts ...WriteOption) *Writer {
+	optSet := toWriteOptSet(opts...)
 	w := dicomio.NewWriter(out, nil, false)
+
+	return &Writer{
+		writer: w,
+		optSet: optSet,
+	}
+}
+
+// SetTransferSyntax sets the transfer syntax for the underlying dicomio.Writer.
+func (w *Writer) SetTransferSyntax(bo binary.ByteOrder, implicit bool) {
+	w.writer.SetTransferSyntax(bo, implicit)
+}
+
+// writeDataset writes the provided DICOM dataset to the Writer, including headers if available.
+func (w *Writer) writeDataset(ds Dataset) error {
 	var metaElems []*Element
 	for _, elem := range ds.Elements {
 		if elem.Tag.Group == tag.MetadataGroup {
@@ -42,25 +59,25 @@ func Write(out io.Writer, ds Dataset, opts ...WriteOption) error {
 		}
 	}
 
-	err := writeFileHeader(w, &ds, metaElems, *optSet)
+	err := writeFileHeader(w.writer, &ds, metaElems, *w.optSet)
 	if err != nil {
 		return err
 	}
 
 	endian, implicit, err := ds.transferSyntax()
-	if (err != nil && err != ErrorElementNotFound) || (err == ErrorElementNotFound && !optSet.defaultMissingTransferSyntax) {
+	if (err != nil && err != ErrorElementNotFound) || (err == ErrorElementNotFound && !w.optSet.defaultMissingTransferSyntax) {
 		return err
 	}
 
-	if err == ErrorElementNotFound && optSet.defaultMissingTransferSyntax {
-		w.SetTransferSyntax(binary.LittleEndian, true)
+	if err == ErrorElementNotFound && w.optSet.defaultMissingTransferSyntax {
+		w.writer.SetTransferSyntax(binary.LittleEndian, true)
 	} else {
-		w.SetTransferSyntax(endian, implicit)
+		w.writer.SetTransferSyntax(endian, implicit)
 	}
 
 	for _, elem := range ds.Elements {
 		if elem.Tag.Group != tag.MetadataGroup {
-			err = writeElement(w, elem, *optSet)
+			err = writeElement(w.writer, elem, *w.optSet)
 			if err != nil {
 				return err
 			}
@@ -68,6 +85,18 @@ func Write(out io.Writer, ds Dataset, opts ...WriteOption) error {
 	}
 
 	return nil
+}
+
+// WriteElement writes a single DICOM element to a Writer.
+func (w *Writer) WriteElement(e *Element) error {
+	return writeElement(w.writer, e, *w.optSet)
+}
+
+// Write will write the input DICOM dataset to the provided io.Writer as a complete DICOM (including any header
+// information if available).
+func Write(out io.Writer, ds Dataset, opts ...WriteOption) error {
+	w := NewWriter(out, opts...)
+	return w.writeDataset(ds)
 }
 
 // WriteOption represents an option that can be passed to WriteDataset. Later options will override previous options if
@@ -106,7 +135,7 @@ type writeOptSet struct {
 	defaultMissingTransferSyntax bool
 }
 
-func toOptSet(opts ...WriteOption) *writeOptSet {
+func toWriteOptSet(opts ...WriteOption) *writeOptSet {
 	optSet := &writeOptSet{}
 	for _, opt := range opts {
 		opt(optSet)
@@ -187,7 +216,7 @@ func writeElement(w dicomio.Writer, elem *Element, opts writeOptSet) error {
 	if err != nil {
 		return err
 	}
-	
+
 	if !opts.skipValueTypeVerification && elem.Value != nil {
 		err := verifyValueType(elem.Tag, elem.Value, vr)
 		if err != nil {

--- a/write.go
+++ b/write.go
@@ -313,7 +313,7 @@ func verifyValueType(t tag.Tag, value Value, vr string) error {
 		ok = valueType == Sequences
 	case "NA":
 		ok = valueType == SequenceItem
-	case vrraw.OtherWord, vrraw.OtherByte, vrraw.Unknown:
+	case vrraw.OtherWord, vrraw.OtherByte:
 		if t == tag.PixelData {
 			ok = valueType == PixelData
 		} else {
@@ -321,6 +321,8 @@ func verifyValueType(t tag.Tag, value Value, vr string) error {
 		}
 	case vrraw.FloatingPointSingle, vrraw.FloatingPointDouble:
 		ok = valueType == Floats
+	case vrraw.Unknown:
+		ok = (valueType == Bytes || valueType == Sequences)
 	default:
 		ok = valueType == Strings
 	}

--- a/write_test.go
+++ b/write_test.go
@@ -47,6 +47,17 @@ func TestWrite(t *testing.T) {
 				mustNewElement(tag.FloatingPointValue, []float64{128.10}),
 				mustNewElement(tag.DimensionIndexPointer, []int{32, 36950}),
 				mustNewElement(tag.RedPaletteColorLookupTableData, []byte{0x1, 0x2, 0x3, 0x4}),
+				mustNewElement(tag.SelectorSLValue, []int{-20}),
+				// Some tag with an unknown VR.
+				{
+					Tag:                    tag.Tag{0x0019, 0x1027},
+					ValueRepresentation:    tag.VRBytes,
+					RawValueRepresentation: "UN",
+					ValueLength:            4,
+					Value: &bytesValue{
+						value: []byte{0x1, 0x2, 0x3, 0x4},
+					},
+				},
 			}},
 			expectedError: nil,
 		},

--- a/write_test.go
+++ b/write_test.go
@@ -51,7 +51,7 @@ func TestWrite(t *testing.T) {
 				// Some tag with an unknown VR.
 				{
 					Tag:                    tag.Tag{0x0019, 0x1027},
-					ValueRepresentation:    tag.VRBytes,
+					ValueRepresentation:    tag.VRUnknown,
 					RawValueRepresentation: "UN",
 					ValueLength:            4,
 					Value: &bytesValue{
@@ -119,7 +119,7 @@ func TestWrite(t *testing.T) {
 							},
 						},
 					},
-				}),
+				}, false),
 			}},
 			expectedError: nil,
 		},
@@ -169,7 +169,7 @@ func TestWrite(t *testing.T) {
 							},
 						},
 					},
-				}),
+				}, false),
 			}},
 			expectedError: nil,
 			opts:          []WriteOption{SkipVRVerification()},
@@ -204,9 +204,45 @@ func TestWrite(t *testing.T) {
 									},
 								},
 							},
-						}),
+						}, false),
 					},
-				}),
+				}, false),
+			}},
+			expectedError: nil,
+		},
+		{
+			name: "nested unknown sequences",
+			dataset: Dataset{Elements: []*Element{
+				mustNewElement(tag.MediaStorageSOPClassUID, []string{"1.2.840.10008.5.1.4.1.1.1.13"}),
+				mustNewElement(tag.MediaStorageSOPInstanceUID, []string{"1.2.3.4.5.6.7"}),
+				mustNewElement(tag.TransferSyntaxUID, []string{uid.ImplicitVRLittleEndian}),
+				mustNewElement(tag.PatientName, []string{"Bob", "Jones"}),
+				makeSequenceElement(tag.Tag{0x0019, 0x1027}, [][]*Element{
+					// Item 1.
+					{
+						{
+							Tag:                    tag.Tag{0x0019, 0x1028},
+							ValueRepresentation:    tag.VRUnknown,
+							RawValueRepresentation: "UN",
+							Value: &bytesValue{
+								value: []byte{0x1, 0x2, 0x3, 0x4},
+							},
+						},
+						// Nested Sequence.
+						makeSequenceElement(tag.Tag{0x0019, 0x1029}, [][]*Element{
+							{
+								{
+									Tag:                    tag.PatientName,
+									ValueRepresentation:    tag.VRStringList,
+									RawValueRepresentation: "PN",
+									Value: &stringsValue{
+										value: []string{"Bob", "Jones"},
+									},
+								},
+							},
+						}, true),
+					},
+				}, true),
 			}},
 			expectedError: nil,
 		},
@@ -240,9 +276,9 @@ func TestWrite(t *testing.T) {
 									},
 								},
 							},
-						}),
+						}, false),
 					},
-				}),
+				}, false),
 			}},
 			expectedError: nil,
 			opts:          []WriteOption{SkipVRVerification()},


### PR DESCRIPTION
This PR is adapted from the [previous one](https://github.com/suyashkumar/dicom/pull/234).

The main new addition it makes to this existing `s/read-un-as-sq` branch is treating unknown elements* as bytes not strings. It also contains changes from a main branch rebase.

*outside of the implicit syntax+undefined length case