### PR TITLE
Add `SkipPixelData` option to `Parser`

### DIFF
--- a/pkg/dicomio/reader.go
+++ b/pkg/dicomio/reader.go
@@ -67,7 +67,12 @@ type Reader interface {
 	// SetCodingSystem sets the charset.CodingSystem to be used when ReadString
 	// is called.
 	SetCodingSystem(cs charset.CodingSystem)
+	// ByteOrder returns the byte order of the reader (endianness)
 	ByteOrder() binary.ByteOrder
+	// SkipPixelData returns whether or not the reader will skip pixel data
+	SkipPixelData() bool
+	// SetSkipPixelData sets whether or not the reader will skip pixel data
+	SetSkipPixelData(bool)
 }
 
 type reader struct {
@@ -80,7 +85,8 @@ type reader struct {
 	// cs represents the CodingSystem to use when reading the string. If a
 	// particular encoding.Decoder within this CodingSystem is nil, assume
 	// ASCII.
-	cs charset.CodingSystem
+	cs            charset.CodingSystem
+	skipPixelData bool
 }
 
 // NewReader creates and returns a new dicomio.Reader.
@@ -238,4 +244,12 @@ func (r *reader) Peek(n int) ([]byte, error) {
 
 func (r *reader) ByteOrder() binary.ByteOrder {
 	return r.bo
+}
+
+func (r *reader) SkipPixelData() bool {
+	return r.skipPixelData
+}
+
+func (r *reader) SetSkipPixelData(skip bool) {
+	r.skipPixelData = skip
 }


### PR DESCRIPTION
 - For heavy imaging modalities, it is expensive to load the pixel
   data into memory, and for many use cases, unnecessary. This new
   option allows users to parse the other attributes without the
   resource hit.

### Testing

```
$ go test -v -run TestNewParser ./...
=== RUN   TestNewParserSkipMetadataReadOnNewParserInit
--- PASS: TestNewParserSkipMetadataReadOnNewParserInit (0.00s)
=== RUN   TestNewParserSkipPixelData
--- PASS: TestNewParserSkipPixelData (0.01s)
=== RUN   TestNewParserPixelData
--- PASS: TestNewParserPixelData (0.62s)
PASS
ok      github.com/suyashkumar/dicom    0.677s
?       github.com/suyashkumar/dicom/cmd/dicomutil      [no test files]
?       github.com/suyashkumar/dicom/mocks/pkg/dicomio  [no test files]
?       github.com/suyashkumar/dicom/pkg/charset        [no test files]
testing: warning: no tests to run
PASS
ok      github.com/suyashkumar/dicom/pkg/dcmtime        0.011s [no tests to run]
?       github.com/suyashkumar/dicom/pkg/debug  [no test files]
?       github.com/suyashkumar/dicom/pkg/dicomio        [no test files]
testing: warning: no tests to run
PASS
ok      github.com/suyashkumar/dicom/pkg/frame  0.003s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/suyashkumar/dicom/pkg/personname     0.017s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/suyashkumar/dicom/pkg/tag    0.007s [no tests to run]
?       github.com/suyashkumar/dicom/pkg/uid    [no test files]
?       github.com/suyashkumar/dicom/pkg/vrraw  [no test files]
```