### PR TITLE
Fix: pixel data mismatch

### DIFF
--- a/cmd/dicomutil/main.go
+++ b/cmd/dicomutil/main.go
@@ -21,10 +21,11 @@ import (
 var GitVersion = "unknown"
 
 var (
-	version             = flag.Bool("version", false, "print current version and exit")
-	filepath            = flag.String("path", "", "path")
-	extractImagesStream = flag.Bool("extract-images-stream", false, "Extract images using frame streaming capability")
-	printJSON           = flag.Bool("json", false, "Print dataset as JSON")
+	version                  = flag.Bool("version", false, "print current version and exit")
+	filepath                 = flag.String("path", "", "path")
+	extractImagesStream      = flag.Bool("extract-images-stream", false, "Extract images using frame streaming capability")
+	printJSON                = flag.Bool("json", false, "Print dataset as JSON")
+	allowPixelDataVLMismatch = flag.Bool("allow-pixel-data-mismatch", false, "Allows the pixel data mismatch")
 )
 
 // FrameBufferSize represents the size of the *Frame buffered channel for streaming calls
@@ -57,7 +58,11 @@ func main() {
 		if *extractImagesStream {
 			ds = parseWithStreaming(f, info.Size())
 		} else {
-			data, err := dicom.Parse(f, info.Size(), nil)
+			var opts []dicom.ParseOption
+			if *allowPixelDataVLMismatch {
+				opts = append(opts, dicom.AllowMismatchPixelDataLength())
+			}
+			data, err := dicom.ParseWithOption(f, info.Size(), nil, opts...)
 			if err != nil {
 				log.Fatalf("error parsing data: %v", err)
 			}
@@ -131,7 +136,8 @@ func writeStreamingFrames(frameChan chan *frame.Frame, doneWG *sync.WaitGroup) {
 func generateImage(fr *frame.Frame, frameIndex int, frameSuffix string, wg *sync.WaitGroup) {
 	i, err := fr.GetImage()
 	if err != nil {
-		log.Fatal("Error while getting image")
+		fmt.Printf("Error while getting image: %v\n", err)
+		return
 	}
 
 	ext := ".jpg"

--- a/cmd/dicomutil/main.go
+++ b/cmd/dicomutil/main.go
@@ -62,7 +62,7 @@ func main() {
 			if *allowPixelDataVLMismatch {
 				opts = append(opts, dicom.AllowMismatchPixelDataLength())
 			}
-			data, err := dicom.ParseWithOption(f, info.Size(), nil, opts...)
+			data, err := dicom.Parse(f, info.Size(), nil, opts...)
 			if err != nil {
 				log.Fatalf("error parsing data: %v", err)
 			}

--- a/dataset.go
+++ b/dataset.go
@@ -23,6 +23,8 @@ var ErrorElementNotFound = errors.New("element not found")
 // within this Dataset (including Elements nested within Sequences).
 type Dataset struct {
 	Elements []*Element `json:"elements"`
+
+	opts parseOptSet
 }
 
 // FindElementByTag searches through the dataset and returns a pointer to the matching element.
@@ -183,7 +185,7 @@ func (d *Dataset) String() string {
 		b.WriteString(fmt.Sprintf("%s  VR: %s\n", tabs, elem.e.ValueRepresentation))
 		b.WriteString(fmt.Sprintf("%s  VR Raw: %s\n", tabs, elem.e.RawValueRepresentation))
 		b.WriteString(fmt.Sprintf("%s  VL: %d\n", tabs, elem.e.ValueLength))
-		b.WriteString(fmt.Sprintf("%s  Value: %d\n", tabs, elem.e.Value))
+		b.WriteString(fmt.Sprintf("%s  Value: %s\n", tabs, elem.e.Value.String()))
 		b.WriteString(fmt.Sprintf("%s]\n\n", tabs))
 	}
 	return b.String()

--- a/dataset_test.go
+++ b/dataset_test.go
@@ -268,7 +268,7 @@ func ExampleDataset_String() {
 	//   VR: VRInt32List
 	//   VR Raw: UL
 	//   VL: 0
-	//   Value: &{[100]}
+	//   Value: [100]
 	// ]
 	//
 	// [
@@ -277,7 +277,7 @@ func ExampleDataset_String() {
 	//   VR: VRInt32List
 	//   VR Raw: UL
 	//   VL: 0
-	//   Value: &{[200]}
+	//   Value: [200]
 	// ]
 
 }

--- a/element.go
+++ b/element.go
@@ -296,9 +296,12 @@ func (s *sequencesValue) MarshalJSON() ([]byte, error) {
 
 // PixelDataInfo is a representation of DICOM PixelData.
 type PixelDataInfo struct {
-	Frames         []frame.Frame
-	IsVLMismatch   bool `json:"isVLMismatch"`
-	IsEncapsulated bool `json:"isEncapsulated"`
+	Frames []frame.Frame
+	// ParsingErr indicates if there was an error when reading this Frame from the DICOM.
+	// If this is set, this means fallback behavior was triggered to blindly write the PixelData bytes to an encapsulated frame.
+	// The ParsingErr will contain details about the specific error encountered.
+	ParsingErr     error `json:"parseErr"`
+	IsEncapsulated bool  `json:"isEncapsulated"`
 	Offsets        []uint32
 }
 
@@ -317,8 +320,8 @@ func (e *pixelDataValue) String() string {
 	if e.IsEncapsulated {
 		return fmt.Sprintf("encapsulated FramesLength=%d Frame[0] size=%d", len(e.Frames), len(e.Frames[0].EncapsulatedData.Data))
 	}
-	if e.IsVLMismatch {
-		return fmt.Sprintf("vlMismatch FramesLength=%d Frame[0] size=%d", len(e.Frames), len(e.Frames[0].EncapsulatedData.Data))
+	if e.ParsingErr != nil {
+		return fmt.Sprintf("parseErr err=%s FramesLength=%d Frame[0] size=%d", e.ParsingErr.Error(), len(e.Frames), len(e.Frames[0].EncapsulatedData.Data))
 	}
 	return fmt.Sprintf("FramesLength=%d FrameSize rows=%d cols=%d", len(e.Frames), e.Frames[0].NativeData.Rows, e.Frames[0].NativeData.Cols)
 }

--- a/element.go
+++ b/element.go
@@ -297,10 +297,10 @@ func (s *sequencesValue) MarshalJSON() ([]byte, error) {
 // PixelDataInfo is a representation of DICOM PixelData.
 type PixelDataInfo struct {
 	Frames []frame.Frame
-	// ParsingErr indicates if there was an error when reading this Frame from the DICOM.
+	// ParseErr indicates if there was an error when reading this Frame from the DICOM.
 	// If this is set, this means fallback behavior was triggered to blindly write the PixelData bytes to an encapsulated frame.
-	// The ParsingErr will contain details about the specific error encountered.
-	ParsingErr     error `json:"parseErr"`
+	// The ParseErr will contain details about the specific error encountered.
+	ParseErr       error `json:"parseErr"`
 	IsEncapsulated bool  `json:"isEncapsulated"`
 	Offsets        []uint32
 }
@@ -320,8 +320,8 @@ func (e *pixelDataValue) String() string {
 	if e.IsEncapsulated {
 		return fmt.Sprintf("encapsulated FramesLength=%d Frame[0] size=%d", len(e.Frames), len(e.Frames[0].EncapsulatedData.Data))
 	}
-	if e.ParsingErr != nil {
-		return fmt.Sprintf("parseErr err=%s FramesLength=%d Frame[0] size=%d", e.ParsingErr.Error(), len(e.Frames), len(e.Frames[0].EncapsulatedData.Data))
+	if e.ParseErr != nil {
+		return fmt.Sprintf("parseErr err=%s FramesLength=%d Frame[0] size=%d", e.ParseErr.Error(), len(e.Frames), len(e.Frames[0].EncapsulatedData.Data))
 	}
 	return fmt.Sprintf("FramesLength=%d FrameSize rows=%d cols=%d", len(e.Frames), e.Frames[0].NativeData.Rows, e.Frames[0].NativeData.Cols)
 }

--- a/element.go
+++ b/element.go
@@ -310,8 +310,13 @@ func (e *pixelDataValue) isElementValue()       {}
 func (e *pixelDataValue) ValueType() ValueType  { return PixelData }
 func (e *pixelDataValue) GetValue() interface{} { return e.PixelDataInfo }
 func (e *pixelDataValue) String() string {
-	// TODO: consider adding more sophisticated formatting
-	return ""
+	if len(e.Frames) == 0 {
+		return "empty pixel data"
+	}
+	if e.IsEncapsulated {
+		return fmt.Sprintf("encapsulated FramesLength=%d FrameSize=%d", len(e.Frames), len(e.Frames[0].EncapsulatedData.Data))
+	}
+	return fmt.Sprintf("FramesLength=%d FrameSize rows=%d cols=%d", len(e.Frames), e.Frames[0].NativeData.Rows, e.Frames[0].NativeData.Cols)
 }
 
 func (e *pixelDataValue) MarshalJSON() ([]byte, error) {

--- a/element.go
+++ b/element.go
@@ -314,7 +314,7 @@ func (e *pixelDataValue) String() string {
 		return "empty pixel data"
 	}
 	if e.IsEncapsulated {
-		return fmt.Sprintf("encapsulated FramesLength=%d FrameSize=%d", len(e.Frames), len(e.Frames[0].EncapsulatedData.Data))
+		return fmt.Sprintf("encapsulated FramesLength=%d Frame[0] size=%d", len(e.Frames), len(e.Frames[0].EncapsulatedData.Data))
 	}
 	return fmt.Sprintf("FramesLength=%d FrameSize rows=%d cols=%d", len(e.Frames), e.Frames[0].NativeData.Rows, e.Frames[0].NativeData.Cols)
 }

--- a/element.go
+++ b/element.go
@@ -297,6 +297,7 @@ func (s *sequencesValue) MarshalJSON() ([]byte, error) {
 // PixelDataInfo is a representation of DICOM PixelData.
 type PixelDataInfo struct {
 	Frames         []frame.Frame
+	IsVLMismatch   bool `json:"isVLMismatch"`
 	IsEncapsulated bool `json:"isEncapsulated"`
 	Offsets        []uint32
 }
@@ -315,6 +316,9 @@ func (e *pixelDataValue) String() string {
 	}
 	if e.IsEncapsulated {
 		return fmt.Sprintf("encapsulated FramesLength=%d Frame[0] size=%d", len(e.Frames), len(e.Frames[0].EncapsulatedData.Data))
+	}
+	if e.IsVLMismatch {
+		return fmt.Sprintf("vlMismatch FramesLength=%d Frame[0] size=%d", len(e.Frames), len(e.Frames[0].EncapsulatedData.Data))
 	}
 	return fmt.Sprintf("FramesLength=%d FrameSize rows=%d cols=%d", len(e.Frames), e.Frames[0].NativeData.Rows, e.Frames[0].NativeData.Cols)
 }

--- a/parse.go
+++ b/parse.go
@@ -51,8 +51,8 @@ var (
 	// need to use this.
 	ErrorEndOfDICOM = errors.New("this indicates to the caller of Next() that the DICOM has been fully parsed")
 
-	// ErrorMismatchPixelDataLength indicates that the size calulated from DICOM mismatch the VL.
-	ErrorMismatchPixelDataLength = errors.New("the size calculated from DICOM elements and VL are mismatch")
+	// ErrorMismatchPixelDataLength indicates that the size calculated from DICOM mismatch the VL.
+	ErrorMismatchPixelDataLength = errors.New("the size calculated from DICOM elements and the PixelData element's VL are mismatched")
 )
 
 // Parse parses the entire DICOM at the input io.Reader into a Dataset of DICOM Elements. Use this if you are

--- a/parse.go
+++ b/parse.go
@@ -294,7 +294,7 @@ func toParseOptSet(opts ...ParseOption) parseOptSet {
 	return optSet
 }
 
-// AllowMismatchPixelDataLength allow parser not returning an error when the length calculated from elements do not match with value length
+// AllowMismatchPixelDataLength allows parser to ignore an error when the length calculated from elements do not match with value length.
 func AllowMismatchPixelDataLength() ParseOption {
 	return func(set *parseOptSet) {
 		set.allowMismatchPixelDataLength = true

--- a/parse.go
+++ b/parse.go
@@ -57,34 +57,12 @@ var (
 
 // Parse parses the entire DICOM at the input io.Reader into a Dataset of DICOM Elements. Use this if you are
 // looking to parse the DICOM all at once, instead of element-by-element.
-func Parse(in io.Reader, bytesToRead int64, frameChan chan *frame.Frame) (Dataset, error) {
-	p, err := NewParser(in, bytesToRead, frameChan)
-	if err != nil {
-		return Dataset{}, err
-	}
-
-	for !p.reader.IsLimitExhausted() {
-		_, err := p.Next()
-		if err != nil {
-			return p.dataset, err
-		}
-	}
-
-	// Close the frameChannel if needed
-	if p.frameChannel != nil {
-		close(p.frameChannel)
-	}
-	return p.dataset, nil
-}
-
-// ParseWithOption parses the entire DICOM at the input io.Reader into a Dataset of DICOM Elements.
-// Allow user to use it with option.
-func ParseWithOption(in io.Reader, bytesToRead int64, frameChan chan *frame.Frame, opts ...ParseOption) (Dataset, error) {
+func Parse(in io.Reader, bytesToRead int64, frameChan chan *frame.Frame, opts ...ParseOption) (Dataset, error) {
 	p, err := NewParser(in, bytesToRead, frameChan, opts...)
 	if err != nil {
 		return Dataset{}, err
 	}
-	
+
 	for !p.reader.IsLimitExhausted() {
 		_, err := p.Next()
 		if err != nil {
@@ -101,7 +79,7 @@ func ParseWithOption(in io.Reader, bytesToRead int64, frameChan chan *frame.Fram
 
 // ParseFile parses the entire DICOM at the given filepath. See dicom.Parse as
 // well for a more generic io.Reader based API.
-func ParseFile(filepath string, frameChan chan *frame.Frame) (Dataset, error) {
+func ParseFile(filepath string, frameChan chan *frame.Frame, opts ...ParseOption) (Dataset, error) {
 	f, err := os.Open(filepath)
 	if err != nil {
 		return Dataset{}, err
@@ -113,7 +91,7 @@ func ParseFile(filepath string, frameChan chan *frame.Frame) (Dataset, error) {
 		return Dataset{}, err
 	}
 
-	return Parse(f, info.Size(), frameChan)
+	return Parse(f, info.Size(), frameChan, opts...)
 }
 
 // Parser is a struct that allows a user to parse Elements from a DICOM element-by-element using Next(), which may be

--- a/pkg/frame/frame.go
+++ b/pkg/frame/frame.go
@@ -20,6 +20,8 @@ type CommonFrame interface {
 	GetImage() (image.Image, error)
 	// IsEncapsulated indicates if the underlying Frame is an EncapsulatedFrame.
 	IsEncapsulated() bool
+	// IsVLMismatch indicates if the pixel-data VL mismatches with calculated value
+	IsVLMismatch() bool
 	// GetNativeFrame attempts to get the underlying NativeFrame (or returns an error)
 	GetNativeFrame() (*NativeFrame, error)
 	// GetEncapsulatedFrame attempts to get the underlying EncapsulatedFrame (or returns an error)
@@ -30,6 +32,9 @@ type CommonFrame interface {
 // TODO: deprecate this old intermediate representation in favor of CommonFrame
 // once happy and solid with API.
 type Frame struct {
+	// VLMismatch indicates if the pixel-data VL mismatches with calculated value
+	// the data will be stored in EncapsulatedData
+	VLMismatch bool
 	// Encapsulated indicates whether the underlying frame is encapsulated or
 	// not.
 	Encapsulated bool
@@ -43,6 +48,9 @@ type Frame struct {
 
 // IsEncapsulated indicates if the frame is encapsulated or not.
 func (f *Frame) IsEncapsulated() bool { return f.Encapsulated }
+
+// IsVLMismatch indicates if the pixel-data VL mismatches with calculated value
+func (f *Frame) IsVLMismatch() bool { return f.VLMismatch }
 
 // GetNativeFrame returns a NativeFrame from this frame. If the underlying frame
 // is not a NativeFrame, ErrorFrameTypeNotPresent will be returned.

--- a/pkg/frame/frame.go
+++ b/pkg/frame/frame.go
@@ -20,8 +20,6 @@ type CommonFrame interface {
 	GetImage() (image.Image, error)
 	// IsEncapsulated indicates if the underlying Frame is an EncapsulatedFrame.
 	IsEncapsulated() bool
-	// IsVLMismatch indicates if the pixel-data VL mismatches with calculated value
-	IsVLMismatch() bool
 	// GetNativeFrame attempts to get the underlying NativeFrame (or returns an error)
 	GetNativeFrame() (*NativeFrame, error)
 	// GetEncapsulatedFrame attempts to get the underlying EncapsulatedFrame (or returns an error)
@@ -32,9 +30,6 @@ type CommonFrame interface {
 // TODO: deprecate this old intermediate representation in favor of CommonFrame
 // once happy and solid with API.
 type Frame struct {
-	// VLMismatch indicates if the pixel-data VL mismatches with calculated value
-	// the data will be stored in EncapsulatedData
-	VLMismatch bool
 	// Encapsulated indicates whether the underlying frame is encapsulated or
 	// not.
 	Encapsulated bool
@@ -48,9 +43,6 @@ type Frame struct {
 
 // IsEncapsulated indicates if the frame is encapsulated or not.
 func (f *Frame) IsEncapsulated() bool { return f.Encapsulated }
-
-// IsVLMismatch indicates if the pixel-data VL mismatches with calculated value
-func (f *Frame) IsVLMismatch() bool { return f.VLMismatch }
 
 // GetNativeFrame returns a NativeFrame from this frame. If the underlying frame
 // is not a NativeFrame, ErrorFrameTypeNotPresent will be returned.

--- a/read.go
+++ b/read.go
@@ -225,7 +225,7 @@ func makeErrorPixelData(reader io.Reader, vl uint32, fc chan<- *frame.Frame, par
 	data := make([]byte, vl)
 	_, err := io.ReadFull(reader, data)
 	if err != nil {
-		return nil, fmt.Errorf("read pixelData: %w", err)
+		return nil, fmt.Errorf("makeErrorPixelData: read pixelData: %w", err)
 	}
 
 	f := frame.Frame{
@@ -238,8 +238,8 @@ func makeErrorPixelData(reader io.Reader, vl uint32, fc chan<- *frame.Frame, par
 		fc <- &f
 	}
 	image := PixelDataInfo{
-		ParsingErr: parseErr,
-		Frames:     []frame.Frame{f},
+		ParseErr: parseErr,
+		Frames:   []frame.Frame{f},
 	}
 	return &image, nil
 }

--- a/read.go
+++ b/read.go
@@ -289,7 +289,6 @@ func readNativeFrames(d dicomio.Reader, parsedData *Dataset, fc chan<- *frame.Fr
 		}
 
 		f := frame.Frame{
-			VLMismatch: true,
 			EncapsulatedData: frame.EncapsulatedFrame{
 				Data: data,
 			},
@@ -299,7 +298,7 @@ func readNativeFrames(d dicomio.Reader, parsedData *Dataset, fc chan<- *frame.Fr
 			fc <- &f
 		}
 		image := PixelDataInfo{
-			IsVLMismatch: true,
+			ParsingErr: ErrorMismatchPixelDataLength,
 		}
 		image.Frames = append(image.Frames, f)
 		return &image, int(vl), nil

--- a/read.go
+++ b/read.go
@@ -110,10 +110,11 @@ func readValue(r dicomio.Reader, t tag.Tag, vr string, vl uint32, isImplicit boo
 	case tag.VRUInt16List, tag.VRUInt32List, tag.VRInt16List, tag.VRInt32List, tag.VRTagList:
 		return readInt(r, t, vr, vl)
 	case tag.VRSequence:
-		return readSequence(r, t, vr, vl)
+		return readSequence(r, t, vr, vl, d)
 	case tag.VRItem:
-		return readSequenceItem(r, t, vr, vl)
+		return readSequenceItem(r, t, vr, vl, d)
 	case tag.VRPixelData:
+
 		return readPixelData(r, t, vr, vl, d, fc)
 	case tag.VRFloat32List, tag.VRFloat64List:
 		return readFloat(r, t, vr, vl)
@@ -225,10 +226,6 @@ func fillBufferSingleBitAllocated(pixelData []int, d dicomio.Reader, bo binary.B
 // that should be available in parsedData (elements like NumberOfFrames, rows, columns, etc)
 func readNativeFrames(d dicomio.Reader, parsedData *Dataset, fc chan<- *frame.Frame, vl uint32) (pixelData *PixelDataInfo,
 	bytesRead int, err error) {
-	image := PixelDataInfo{
-		IsEncapsulated: false,
-	}
-
 	// Parse information from previously parsed attributes that are needed to parse NativeData Frames:
 	rows, err := parsedData.FindElementByTag(tag.Rows)
 	if err != nil {
@@ -269,10 +266,52 @@ func readNativeFrames(d dicomio.Reader, parsedData *Dataset, fc chan<- *frame.Fr
 
 	debug.Logf("readNativeFrames:\nRows: %d\nCols:%d\nFrames::%d\nBitsAlloc:%d\nSamplesPerPixel:%d", MustGetInts(rows.Value)[0], MustGetInts(cols.Value)[0], nFrames, bitsAllocated, samplesPerPixel)
 
+	bytesAllocated := bitsAllocated / 8
+	bytesRead = bytesAllocated * samplesPerPixel * pixelsPerFrame * nFrames
+	if bitsAllocated == 1 {
+		bytesRead = pixelsPerFrame * samplesPerPixel / 8 * nFrames
+	}
+
+	skipOne := false
+	switch {
+	case uint32(bytesRead) == vl: // we good nothing
+	case uint32(bytesRead) == vl-1 && vl%2 == 0:
+		skipOne = true
+	case uint32(bytesRead) == vl-1 && vl%2 != 0:
+		return nil, 0, fmt.Errorf("vl=%d: %w", vl, ErrorExpectedEvenLength)
+	default:
+		if !parsedData.opts.allowMismatchPixelDataLength {
+			return nil, 0, fmt.Errorf("expected_vl=%d actual_vl=%d %w", bytesRead, vl, ErrorMismatchPixelDataLength)
+		}
+		data := make([]byte, vl)
+		_, err = io.ReadFull(d, data)
+		if err != nil {
+			panic(err)
+		}
+
+		f := frame.Frame{
+			Encapsulated: true,
+			EncapsulatedData: frame.EncapsulatedFrame{
+				Data: data,
+			},
+		}
+
+		if fc != nil {
+			fc <- &f
+		}
+		image := PixelDataInfo{
+			IsEncapsulated: true,
+		}
+		image.Frames = append(image.Frames, f)
+		return &image, int(vl), nil
+	}
+
 	// Parse the pixels:
+	image := PixelDataInfo{
+		IsEncapsulated: false,
+	}
 	image.Frames = make([]frame.Frame, nFrames)
 	bo := d.ByteOrder()
-	bytesAllocated := bitsAllocated / 8
 	pixelBuf := make([]byte, bytesAllocated)
 	for frameIdx := 0; frameIdx < nFrames; frameIdx++ {
 		// Init current frame
@@ -282,28 +321,27 @@ func readNativeFrames(d dicomio.Reader, parsedData *Dataset, fc chan<- *frame.Fr
 				BitsPerSample: bitsAllocated,
 				Rows:          MustGetInts(rows.Value)[0],
 				Cols:          MustGetInts(cols.Value)[0],
-				Data:          make([][]int, int(pixelsPerFrame)),
+				Data:          make([][]int, pixelsPerFrame),
 			},
 		}
-		buf := make([]int, int(pixelsPerFrame)*samplesPerPixel)
+		buf := make([]int, pixelsPerFrame*samplesPerPixel)
 		if bitsAllocated == 1 {
 			if err := fillBufferSingleBitAllocated(buf, d, bo); err != nil {
 				return nil, bytesRead, err
 			}
-			for pixel := 0; pixel < int(pixelsPerFrame); pixel++ {
+			for pixel := 0; pixel < pixelsPerFrame; pixel++ {
 				for value := 0; value < samplesPerPixel; value++ {
 					currentFrame.NativeData.Data[pixel] = buf[pixel*samplesPerPixel : (pixel+1)*samplesPerPixel]
 				}
 			}
 		} else {
-			for pixel := 0; pixel < int(pixelsPerFrame); pixel++ {
+			for pixel := 0; pixel < pixelsPerFrame; pixel++ {
 				for value := 0; value < samplesPerPixel; value++ {
 					_, err := io.ReadFull(d, pixelBuf)
 					if err != nil {
 						return nil, bytesRead,
 							fmt.Errorf("could not read uint%d from input: %w", bitsAllocated, err)
 					}
-
 					if bitsAllocated == 8 {
 						buf[(pixel*samplesPerPixel)+value] = int(pixelBuf[0])
 					} else if bitsAllocated == 16 {
@@ -311,7 +349,7 @@ func readNativeFrames(d dicomio.Reader, parsedData *Dataset, fc chan<- *frame.Fr
 					} else if bitsAllocated == 32 {
 						buf[(pixel*samplesPerPixel)+value] = int(bo.Uint32(pixelBuf))
 					} else {
-						return nil, bytesRead, fmt.Errorf("unsupported BitsAllocated value of: %d : %w", bitsAllocated, ErrorUnsupportedBitsAllocated)
+						return nil, bytesRead, fmt.Errorf("bitsAllocated=%d : %w", bitsAllocated, ErrorUnsupportedBitsAllocated)
 					}
 				}
 				currentFrame.NativeData.Data[pixel] = buf[pixel*samplesPerPixel : (pixel+1)*samplesPerPixel]
@@ -322,13 +360,7 @@ func readNativeFrames(d dicomio.Reader, parsedData *Dataset, fc chan<- *frame.Fr
 			fc <- &currentFrame // write the current frame to the frame channel
 		}
 	}
-
-	bytesRead = bytesAllocated * samplesPerPixel * pixelsPerFrame * nFrames
-	if vl > 0 && uint32(bytesRead) == vl-1 {
-		if vl%2 != 0 {
-			// this error should never happen if the file conforms to the DICOM spec
-			return nil, bytesRead, fmt.Errorf("odd number of bytes specified for PixelData violates DICOM spec: %d : %w", vl, ErrorExpectedEvenLength)
-		}
+	if skipOne {
 		err := d.Skip(1)
 		if err != nil {
 			return nil, bytesRead, fmt.Errorf("could not read padding byte: %w", err)
@@ -341,12 +373,13 @@ func readNativeFrames(d dicomio.Reader, parsedData *Dataset, fc chan<- *frame.Fr
 // readSequence reads a sequence element (VR = SQ) that contains a subset of Items. Each item contains
 // a set of Elements.
 // See http://dicom.nema.org/medical/dicom/current/output/chtml/part05/sect_7.5.2.html#table_7.5-1
-func readSequence(r dicomio.Reader, t tag.Tag, vr string, vl uint32) (Value, error) {
+func readSequence(r dicomio.Reader, t tag.Tag, vr string, vl uint32, d *Dataset) (Value, error) {
 	var sequences sequencesValue
 
+	seqElements := &Dataset{opts: d.opts}
 	if vl == tag.VLUndefinedLength {
 		for {
-			subElement, err := readElement(r, nil, nil)
+			subElement, err := readElement(r, seqElements, nil)
 			if err != nil {
 				// Stop reading due to error
 				log.Println("error reading subitem, ", err)
@@ -373,7 +406,7 @@ func readSequence(r dicomio.Reader, t tag.Tag, vr string, vl uint32) (Value, err
 			return nil, err
 		}
 		for !r.IsLimitExhausted() {
-			subElement, err := readElement(r, nil, nil)
+			subElement, err := readElement(r, seqElements, nil)
 			if err != nil {
 				// TODO: option to ignore errors parsing subelements?
 				return nil, err
@@ -390,12 +423,12 @@ func readSequence(r dicomio.Reader, t tag.Tag, vr string, vl uint32) (Value, err
 
 // readSequenceItem reads an item component of a sequence dicom element and returns an Element
 // with a SequenceItem value.
-func readSequenceItem(r dicomio.Reader, t tag.Tag, vr string, vl uint32) (Value, error) {
+func readSequenceItem(r dicomio.Reader, t tag.Tag, vr string, vl uint32, d *Dataset) (Value, error) {
 	var sequenceItem SequenceItemValue
 
 	// seqElements holds items read so far.
 	// TODO: deduplicate with sequenceItem above
-	var seqElements Dataset
+	seqElements := Dataset{opts: d.opts}
 
 	if vl == tag.VLUndefinedLength {
 		for {

--- a/read.go
+++ b/read.go
@@ -289,7 +289,7 @@ func readNativeFrames(d dicomio.Reader, parsedData *Dataset, fc chan<- *frame.Fr
 		}
 
 		f := frame.Frame{
-			Encapsulated: true,
+			VLMismatch: true,
 			EncapsulatedData: frame.EncapsulatedFrame{
 				Data: data,
 			},
@@ -299,7 +299,7 @@ func readNativeFrames(d dicomio.Reader, parsedData *Dataset, fc chan<- *frame.Fr
 			fc <- &f
 		}
 		image := PixelDataInfo{
-			IsEncapsulated: true,
+			IsVLMismatch: true,
 		}
 		image.Frames = append(image.Frames, f)
 		return &image, int(vl), nil

--- a/read_test.go
+++ b/read_test.go
@@ -367,7 +367,7 @@ func TestReadNativeFrames(t *testing.T) {
 			}, opts: parseOptSet{allowMismatchPixelDataLength: true}},
 			data: []uint16{1, 2, 3, 2, 1, 2, 3, 2, 1, 2, 3, 2, 1, 2, 3, 2, 2},
 			expectedPixelData: &PixelDataInfo{
-				ParsingErr: ErrorMismatchPixelDataLength,
+				ParseErr: ErrorMismatchPixelDataLength,
 				Frames: []frame.Frame{
 					{
 						EncapsulatedData: frame.EncapsulatedFrame{

--- a/read_test.go
+++ b/read_test.go
@@ -403,7 +403,7 @@ func TestReadNativeFrames(t *testing.T) {
 			expectedError:     ErrorUnsupportedBitsAllocated,
 		},
 		{
-			Name: "3x3, 3 framesples/pixel, data bytes with padded 0",
+			Name: "3x3, 3 frames, 1 samples/pixel, data bytes with padded 0",
 			existingData: Dataset{Elements: []*Element{
 				mustNewElement(tag.Rows, []int{3}),
 				mustNewElement(tag.Columns, []int{3}),

--- a/read_test.go
+++ b/read_test.go
@@ -365,10 +365,10 @@ func TestReadNativeFrames(t *testing.T) {
 			}, opts: parseOptSet{allowMismatchPixelDataLength: true}},
 			data: []uint16{1, 2, 3, 2, 1, 2, 3, 2, 1, 2, 3, 2, 1, 2, 3, 2, 2},
 			expectedPixelData: &PixelDataInfo{
-				IsEncapsulated: true,
+				IsVLMismatch: true,
 				Frames: []frame.Frame{
 					{
-						Encapsulated: true,
+						VLMismatch: true,
 						EncapsulatedData: frame.EncapsulatedFrame{
 							Data: []byte{1, 0, 2, 0, 3, 0, 2, 0, 1, 0, 2, 0, 3, 0, 2, 0, 1, 0, 2, 0, 3, 0, 2, 0, 1, 0, 2, 0, 3, 0, 2, 0, 2, 0},
 						},

--- a/read_test.go
+++ b/read_test.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/suyashkumar/dicom/pkg/vrraw"
 
 	"github.com/suyashkumar/dicom/pkg/dicomio"
@@ -365,10 +367,9 @@ func TestReadNativeFrames(t *testing.T) {
 			}, opts: parseOptSet{allowMismatchPixelDataLength: true}},
 			data: []uint16{1, 2, 3, 2, 1, 2, 3, 2, 1, 2, 3, 2, 1, 2, 3, 2, 2},
 			expectedPixelData: &PixelDataInfo{
-				IsVLMismatch: true,
+				ParsingErr: ErrorMismatchPixelDataLength,
 				Frames: []frame.Frame{
 					{
-						VLMismatch: true,
 						EncapsulatedData: frame.EncapsulatedFrame{
 							Data: []byte{1, 0, 2, 0, 3, 0, 2, 0, 1, 0, 2, 0, 3, 0, 2, 0, 1, 0, 2, 0, 3, 0, 2, 0, 1, 0, 2, 0, 3, 0, 2, 0, 2, 0},
 						},
@@ -549,7 +550,7 @@ func TestReadNativeFrames(t *testing.T) {
 				t.Errorf("TestReadNativeFrames(%v): did not read expected number of bytes. got: %d, want: %d", tc.data, bytesRead, expectedBytes)
 			}
 
-			if diff := cmp.Diff(tc.expectedPixelData, pixelData); diff != "" {
+			if diff := cmp.Diff(tc.expectedPixelData, pixelData, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("TestReadNativeFrames(%v): unexpected diff: %v", tc.data, diff)
 			}
 		})


### PR DESCRIPTION
Sometimes, the VL of pixel data does not match with calculated value. (I can not provide the sample file to test this)
- In this case, we want to return an error rather than continue to parse and returns an EOF error (very hard to debug why)
- This MR also adds a flag to allow ppl to skip the pixelData and mark it as Encapsulated.

