### PR TITLE
Introduce option to SkipPixelData

### DIFF
--- a/element.go
+++ b/element.go
@@ -56,7 +56,7 @@ func (e *Element) String() string {
 //			// or
 //			s := myvalue.GetValue().([]string)
 //			break;
-// 		case dicom.Bytes:
+//		case dicom.Bytes:
 //			// ...
 //	}
 //
@@ -296,7 +296,11 @@ func (s *sequencesValue) MarshalJSON() ([]byte, error) {
 
 // PixelDataInfo is a representation of DICOM PixelData.
 type PixelDataInfo struct {
-	Frames []frame.Frame
+	// IntentionallySkipped indicates if parsing/processing this PixelData tag
+	// was intentionally skipped. This is likely true if the dicom.SkipPixelData
+	// option was set. If true, the rest of this PixelDataInfo will be empty.
+	IntentionallySkipped bool
+	Frames               []frame.Frame
 	// ParseErr indicates if there was an error when reading this Frame from the DICOM.
 	// If this is set, this means fallback behavior was triggered to blindly write the PixelData bytes to an encapsulated frame.
 	// The ParseErr will contain details about the specific error encountered.

--- a/parse.go
+++ b/parse.go
@@ -210,6 +210,7 @@ type ParseOption func(*parseOptSet)
 type parseOptSet struct {
 	skipMetadataReadOnNewParserInit bool
 	allowMismatchPixelDataLength    bool
+	skipPixelData                   bool
 }
 
 func toParseOptSet(opts ...ParseOption) parseOptSet {
@@ -232,5 +233,14 @@ func AllowMismatchPixelDataLength() ParseOption {
 func SkipMetadataReadOnNewParserInit() ParseOption {
 	return func(set *parseOptSet) {
 		set.skipMetadataReadOnNewParserInit = true
+	}
+}
+
+// SkipPixelData skips parsing/processing the PixelData tag, wherever it appears
+// (e.g. even if within an IconSequence). A PixelDataInfo will be added to the
+// Dataset with the IntentionallySkipped property set to true.
+func SkipPixelData() ParseOption {
+	return func(set *parseOptSet) {
+		set.skipPixelData = true
 	}
 }

--- a/read.go
+++ b/read.go
@@ -225,7 +225,6 @@ func (r *reader) readPixelData(vl uint32, d *Dataset, fc chan<- *frame.Frame) (V
 	}
 
 	if r.opts.skipPixelData {
-		log.Println("skip pixeldata")
 		// If we're here, it means the VL isn't undefined length, so we should
 		// be able to safely skip the native PixelData.
 		if err := r.rawReader.Skip(int64(vl)); err != nil {
@@ -777,43 +776,6 @@ func (r *reader) readRawItem(shouldSkip bool) ([]byte, bool, error) {
 		return data, false, nil
 	}
 	return nil, false, nil
-}
-
-func (r *reader) skipRawItem() (bool, error) {
-	t, err := r.readTag()
-	if err != nil {
-		return true, err
-	}
-	// Item is always encoded implicit. PS3.6 7.5
-	vr, err := r.readVR(true, *t)
-	if err != nil {
-		return true, err
-	}
-	vl, err := r.readVL(true, *t, vr)
-	if err != nil {
-		return true, err
-	}
-
-	if *t == tag.SequenceDelimitationItem {
-		if vl != 0 {
-			log.Printf("SequenceDelimitationItem's VL != 0: %d", vl)
-		}
-		return true, nil
-	}
-
-	if *t != tag.Item {
-		log.Printf("Expect Item in pixeldata but found tag %s", tag.DebugString(*t))
-		return false, nil
-	}
-	if vl == tag.VLUndefinedLength {
-		log.Println("Expect defined-length item in pixeldata")
-		return false, nil
-	}
-	if vr != "NA" {
-		return true, fmt.Errorf("readRawItem: expected VR=NA, got VR=%s", vr)
-	}
-
-	return false, nil
 }
 
 // moreToRead returns true if there is more to read from the underlying dicom.


### PR DESCRIPTION
This introduces an option to SkipPixelData processing, making use of the new reader struct introduced in #254.

See also, review discussion in #243 that helped motivate the changes I wanted to make in #254.