### PR TITLE
Benchmark across Parse options, add memory benchmarking.

### DIFF
--- a/.github/workflows/bench_pr.yml
+++ b/.github/workflows/bench_pr.yml
@@ -25,11 +25,11 @@ jobs:
        go install golang.org/x/perf/cmd/benchstat@latest
        echo "New Commit:"
        git log -1 --format="%H"
-       go test -bench=. -benchtime=.75s -count=8 > $HOME/new.txt
+       go test -bench=. -benchmem -benchtime=10x -count=7 > $HOME/new.txt
        git reset --hard HEAD
        git checkout $GITHUB_BASE_REF
        echo "Base Commit:"
        git log -1 --format="%H"
-       go test -bench=. -benchtime=.75s -count=8 > $HOME/old.txt
+       go test -bench=. -benchmem -benchtime=10x -count=7 > $HOME/old.txt
        $GOBIN/benchstat $HOME/old.txt $HOME/new.txt
        

--- a/.github/workflows/bench_push.yml
+++ b/.github/workflows/bench_push.yml
@@ -25,10 +25,10 @@ jobs:
        go install golang.org/x/perf/cmd/benchstat@latest
        echo "New Commit:"
        git log -1 --format="%H"
-       go test -bench=. -benchtime=.75s -count=8 > $HOME/new.txt
+       go test -bench=. -benchmem -benchtime=10x -count=7 > $HOME/new.txt
        git reset --hard HEAD
        git checkout HEAD~1
        echo "Base Commit:"
        git log -1 --format="%H"
-       go test -bench=. -benchtime=.75s -count=8 > $HOME/old.txt
+       go test -bench=. -benchmem -benchtime=10x -count=7 > $HOME/old.txt
        $GOBIN/benchstat $HOME/old.txt $HOME/new.txt

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,10 @@ release:
 	tar -zcvf ${BINARY}-darwin-amd64.tar.gz ${BINARY}-darwin-amd64; \
 	zip -r ${BINARY}-windows-amd64.exe.zip ${BINARY}-windows-amd64.exe;
 
+.PHONY: bench
+bench:
+	go test -bench . -benchmem -benchtime=10x 
+
 bench-diff:
 	go test -bench . -benchmem -benchtime=10x -count 5 > bench_current.txt
 	git checkout main

--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,8 @@ release:
 	zip -r ${BINARY}-windows-amd64.exe.zip ${BINARY}-windows-amd64.exe;
 
 bench-diff:
-	go test -bench . -benchtime=50x -count 5 > bench_current.txt
+	go test -bench . -benchmem -benchtime=10x -count 5 > bench_current.txt
 	git checkout main
-	go test -bench . -benchtime=50x -count 5 > bench_main.txt
+	go test -bench . -benchmem -benchtime=10x -count 5 > bench_main.txt
 	benchstat bench_main.txt bench_current.txt
 	git checkout -


### PR DESCRIPTION
This change updates the Parse benchmark to operate across useful ParseOptions, adds memory benchmarking, and updates some benchmark params. 

For example, we can take a look at the CPU / memory differences across the new ParseOptions for one of the test dicoms:
```
BenchmarkParse/NoOptions/4.dcm-4                                     	      10	 106876945 ns/op	120572543 B/op	    2160 allocs/op
BenchmarkParse/SkipPixelData/4.dcm-4                                 	      10	    531193 ns/op	   34900 B/op	    2144 allocs/op
BenchmarkParse/SkipProcessingPixelDataValue/4.dcm-4                  	      10	   1807256 ns/op	 7573518 B/op	    2146 allocs/op
```