### PR TITLE
allow for reading until EOF with the function ParseUntilEOF

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
   <h3 align="center">dicom</h3>
   <p align="center">High Performance Golang DICOM Medical Image Parser<p>
   <p align="center"> 
-    <a href="https://github.com/suyashkumar/dicom/actions"><img src="https://github.com/suyashkumar/dicom/workflows/build/badge.svg" /></a> 
-    <a href="https://godoc.org/github.com/suyashkumar/dicom"><img src="https://godoc.org/github.com/suyashkumar/dicom?status.svg" alt="" /></a>
-    <a href="https://goreportcard.com/report/github.com/suyashkumar/dicom"><img src="https://goreportcard.com/badge/github.com/suyashkumar/dicom" alt=""></a> 
+    <a href="https://github.com/amitbet/dicom/actions"><img src="https://github.com/amitbet/dicom/workflows/build/badge.svg" /></a> 
+    <a href="https://godoc.org/github.com/amitbet/dicom"><img src="https://godoc.org/github.com/amitbet/dicom?status.svg" alt="" /></a>
+    <a href="https://goreportcard.com/report/github.com/amitbet/dicom"><img src="https://goreportcard.com/badge/github.com/amitbet/dicom" alt=""></a> 
   </p>
 </p>
 
@@ -25,7 +25,7 @@ Some notable features:
 - [x] Modern, canonical Go.
 
 ## Usage
-To use this in your golang project, import `github.com/suyashkumar/dicom`. This repository supports Go modules, and regularly tags releases using semantic versioning. Typical usage is straightforward:
+To use this in your golang project, import `github.com/amitbet/dicom`. This repository supports Go modules, and regularly tags releases using semantic versioning. Typical usage is straightforward:
 ```go 
 
 dataset, _ := dicom.ParseFile("testdata/1.dcm", nil) // See also: dicom.Parse which has a generic io.Reader API.
@@ -37,13 +37,13 @@ fmt.Println(dataset)
 j, _ := json.Marshal(dataset)
 fmt.Println(j)
 ```
-More details about the package (and additional examples and APIs) can be found in the [godoc](https://godoc.org/github.com/suyashkumar/dicom).
+More details about the package (and additional examples and APIs) can be found in the [godoc](https://godoc.org/github.com/amitbet/dicom).
 
 ## CLI Tool
 A CLI tool that uses this package to parse imagery and metadata out of DICOMs is provided in the `cmd/dicomutil` package. This tool can take in a DICOM, and dump out all the elements to STDOUT, in addition to writing out any imagery to the current working directory either as PNGs or JPEG (note, it does not perform any automatic color rescaling by default).
 
 ### Installation
-You can download the prebuilt binaries from the [releases tab](https://github.com/suyashkumar/dicom/releases), or use the following to download the binary at the command line using my [getbin tool](https://github.com/suyashkumar/getbin):
+You can download the prebuilt binaries from the [releases tab](https://github.com/amitbet/dicom/releases), or use the following to download the binary at the command line using my [getbin tool](https://github.com/suyashkumar/getbin):
 
 ```sh
 wget -qO- "https://getbin.io/suyashkumar/dicom" | tar xvz
@@ -74,13 +74,13 @@ go build -o dicomutil ./cmd/dicomutil
 Here's a little more history on this repository for those who are interested! 
 
 ### v0
-The v0 [suyashkumar/dicom](https://github.com/suyashkumar/dicom) started off as a hard fork of [go-dicom](https://github.com/gillesdemey/go-dicom) which was not being maintained actively anymore (with the [original author being supportive of my fork](https://www.reddit.com/r/golang/comments/bnu47l/high_performance_dicom_medical_image_parser_in/en9hp6h?utm_source=share&utm_medium=web2x&context=3)--thank you!). I worked on adding several new capabilities, bug fixes, and general maintainability refactors (like multiframe support, streaming parsing, updated APIs, low-level parsing bug fixes, and more).
+The v0 [suyashkumar/dicom](https://github.com/amitbet/dicom) started off as a hard fork of [go-dicom](https://github.com/gillesdemey/go-dicom) which was not being maintained actively anymore (with the [original author being supportive of my fork](https://www.reddit.com/r/golang/comments/bnu47l/high_performance_dicom_medical_image_parser_in/en9hp6h?utm_source=share&utm_medium=web2x&context=3)--thank you!). I worked on adding several new capabilities, bug fixes, and general maintainability refactors (like multiframe support, streaming parsing, updated APIs, low-level parsing bug fixes, and more).
 
 That represents the __v0__ history of the repository. 
 
 ### v1
 
-For __v1__ I rewrote and redesigned the core library essentially from scratch, and added several new features and bug fixes that only live in __v1__. The architecture and APIs are completely different, as is some of the underlying parser logic (to be more efficient and correct). Most of the core rewrite work happened at the [`s/1.0-rewrite`](https://github.com/suyashkumar/dicom/tree/s/1.0-rewrite) branch. 
+For __v1__ I rewrote and redesigned the core library essentially from scratch, and added several new features and bug fixes that only live in __v1__. The architecture and APIs are completely different, as is some of the underlying parser logic (to be more efficient and correct). Most of the core rewrite work happened at the [`s/1.0-rewrite`](https://github.com/amitbet/dicom/tree/s/1.0-rewrite) branch. 
 
 
 ## Acknowledgements

--- a/cmd/dicomutil/main.go
+++ b/cmd/dicomutil/main.go
@@ -12,9 +12,9 @@ import (
 	"os"
 	"sync"
 
-	"github.com/suyashkumar/dicom"
-	"github.com/suyashkumar/dicom/pkg/frame"
-	"github.com/suyashkumar/dicom/pkg/tag"
+	"github.com/amitbet/dicom"
+	"github.com/amitbet/dicom/pkg/frame"
+	"github.com/amitbet/dicom/pkg/tag"
 )
 
 // GitVersion is the current version of dicomutil, will be replaced in release step with current git commit hash or tag.

--- a/dataset.go
+++ b/dataset.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/suyashkumar/dicom/pkg/tag"
-	"github.com/suyashkumar/dicom/pkg/uid"
+	"github.com/amitbet/dicom/pkg/tag"
+	"github.com/amitbet/dicom/pkg/uid"
 )
 
 // ErrorElementNotFound indicates that the requested element was not found in

--- a/dataset_test.go
+++ b/dataset_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/amitbet/dicom/pkg/tag"
 	"github.com/google/go-cmp/cmp"
-	"github.com/suyashkumar/dicom/pkg/tag"
 )
 
 func makeSequenceElement(tg tag.Tag, items [][]*Element) *Element {

--- a/element.go
+++ b/element.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/suyashkumar/dicom/pkg/frame"
-	"github.com/suyashkumar/dicom/pkg/tag"
+	"github.com/amitbet/dicom/pkg/frame"
+	"github.com/amitbet/dicom/pkg/tag"
 )
 
 // ErrorUnexpectedDataType indicates that an unexpected (not allowed) data type was sent to NewValue.

--- a/element_test.go
+++ b/element_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/suyashkumar/dicom/pkg/tag"
+	"github.com/amitbet/dicom/pkg/tag"
 )
 
 func TestElement_MarshalJSON_NestedElements(t *testing.T) {

--- a/fuzz/dicom_fuzz_test.go
+++ b/fuzz/dicom_fuzz_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/suyashkumar/dicom"
+	"github.com/amitbet/dicom"
 )
 
 func FuzzDICOMParse(f *testing.F) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/suyashkumar/dicom
+module github.com/amitbet/dicom
 
 go 1.18
 

--- a/mocks/pkg/dicomio/mock_reader.go
+++ b/mocks/pkg/dicomio/mock_reader.go
@@ -7,7 +7,7 @@ package mock_dicomio
 import (
 	binary "encoding/binary"
 	gomock "github.com/golang/mock/gomock"
-	charset "github.com/suyashkumar/dicom/pkg/charset"
+	charset "github.com/amitbet/dicom/pkg/charset"
 	reflect "reflect"
 )
 

--- a/parse.go
+++ b/parse.go
@@ -27,12 +27,12 @@ import (
 	"io"
 	"os"
 
-	"github.com/suyashkumar/dicom/pkg/charset"
-	"github.com/suyashkumar/dicom/pkg/debug"
-	"github.com/suyashkumar/dicom/pkg/dicomio"
-	"github.com/suyashkumar/dicom/pkg/frame"
-	"github.com/suyashkumar/dicom/pkg/tag"
-	"github.com/suyashkumar/dicom/pkg/uid"
+	"github.com/amitbet/dicom/pkg/charset"
+	"github.com/amitbet/dicom/pkg/debug"
+	"github.com/amitbet/dicom/pkg/dicomio"
+	"github.com/amitbet/dicom/pkg/frame"
+	"github.com/amitbet/dicom/pkg/tag"
+	"github.com/amitbet/dicom/pkg/uid"
 )
 
 const (

--- a/parse.go
+++ b/parse.go
@@ -75,8 +75,12 @@ func parseInternal(in io.Reader, bytesToRead int64, frameChan chan *frame.Frame,
 		_, err := p.Next()
 		if err != nil {
 			if err.Error() == "EOF" {
+				// exiting on EOF
 				err = nil
+				break
 			}
+
+			// exit on error
 			return p.dataset, err
 		}
 	}

--- a/parse_test.go
+++ b/parse_test.go
@@ -10,11 +10,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/suyashkumar/dicom/pkg/tag"
+	"github.com/amitbet/dicom/pkg/tag"
 
-	"github.com/suyashkumar/dicom/pkg/frame"
+	"github.com/amitbet/dicom/pkg/frame"
 
-	"github.com/suyashkumar/dicom"
+	"github.com/amitbet/dicom"
 )
 
 // TestParse is an end-to-end sanity check over DICOMs in testdata/. Currently,

--- a/pkg/dcmtime/date_test.go
+++ b/pkg/dcmtime/date_test.go
@@ -2,9 +2,10 @@ package dcmtime_test
 
 import (
 	"errors"
-	"github.com/suyashkumar/dicom/pkg/dcmtime"
 	"testing"
 	"time"
+
+	"github.com/amitbet/dicom/pkg/dcmtime"
 )
 
 func TestParseDate(t *testing.T) {

--- a/pkg/dcmtime/datetime_test.go
+++ b/pkg/dcmtime/datetime_test.go
@@ -2,9 +2,10 @@ package dcmtime_test
 
 import (
 	"errors"
-	"github.com/suyashkumar/dicom/pkg/dcmtime"
 	"testing"
 	"time"
+
+	"github.com/amitbet/dicom/pkg/dcmtime"
 )
 
 func TestParseDatetime(t *testing.T) {

--- a/pkg/dcmtime/time_test.go
+++ b/pkg/dcmtime/time_test.go
@@ -2,9 +2,10 @@ package dcmtime_test
 
 import (
 	"errors"
-	"github.com/suyashkumar/dicom/pkg/dcmtime"
 	"testing"
 	"time"
+
+	"github.com/amitbet/dicom/pkg/dcmtime"
 )
 
 func TestParseTime(t *testing.T) {

--- a/pkg/dicomio/reader.go
+++ b/pkg/dicomio/reader.go
@@ -218,7 +218,8 @@ func (r *reader) PopLimit() {
 }
 
 func (r *reader) IsLimitExhausted() bool {
-	return r.BytesLeftUntilLimit() <= 0
+	// if limit < 0 than we should read until EOF
+	return (r.BytesLeftUntilLimit() <= 0 || r.limit < 0)
 }
 
 func (r *reader) SetTransferSyntax(bo binary.ByteOrder, implicit bool) {

--- a/pkg/dicomio/reader.go
+++ b/pkg/dicomio/reader.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 
-	"github.com/suyashkumar/dicom/pkg/charset"
+	"github.com/amitbet/dicom/pkg/charset"
 	"golang.org/x/text/encoding"
 )
 

--- a/pkg/frame/native_test.go
+++ b/pkg/frame/native_test.go
@@ -4,7 +4,7 @@ import (
 	"image"
 	"testing"
 
-	"github.com/suyashkumar/dicom/pkg/frame"
+	"github.com/amitbet/dicom/pkg/frame"
 )
 
 // point represents a 2D point for testing.

--- a/pkg/personname/examples_test.go
+++ b/pkg/personname/examples_test.go
@@ -2,7 +2,8 @@ package personname_test
 
 import (
 	"fmt"
-	"github.com/suyashkumar/dicom/pkg/personname"
+
+	"github.com/amitbet/dicom/pkg/personname"
 )
 
 // The below test does not pass, I think due to the ideograms being incorrectly

--- a/read.go
+++ b/read.go
@@ -50,6 +50,14 @@ func (r *reader) readTag() (*tag.Tag, error) {
 	if gerr == nil && eerr == nil {
 		return &tag.Tag{Group: group, Element: element}, nil
 	}
+	if gerr != nil || eerr != nil {
+		if gerr.Error() == "EOF" {
+			return nil, gerr
+		}
+		if eerr.Error() == "EOF" {
+			return nil, eerr
+		}
+	}
 	return nil, fmt.Errorf("error reading tag: %v %v", gerr, eerr)
 }
 

--- a/read.go
+++ b/read.go
@@ -11,12 +11,12 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/suyashkumar/dicom/pkg/debug"
-	"github.com/suyashkumar/dicom/pkg/vrraw"
+	"github.com/amitbet/dicom/pkg/debug"
+	"github.com/amitbet/dicom/pkg/vrraw"
 
-	"github.com/suyashkumar/dicom/pkg/dicomio"
-	"github.com/suyashkumar/dicom/pkg/frame"
-	"github.com/suyashkumar/dicom/pkg/tag"
+	"github.com/amitbet/dicom/pkg/dicomio"
+	"github.com/amitbet/dicom/pkg/frame"
+	"github.com/amitbet/dicom/pkg/tag"
 )
 
 var (

--- a/read_test.go
+++ b/read_test.go
@@ -11,14 +11,14 @@ import (
 
 	"github.com/google/go-cmp/cmp/cmpopts"
 
-	"github.com/suyashkumar/dicom/pkg/vrraw"
+	"github.com/amitbet/dicom/pkg/vrraw"
 
-	"github.com/suyashkumar/dicom/pkg/dicomio"
-	"github.com/suyashkumar/dicom/pkg/frame"
+	"github.com/amitbet/dicom/pkg/dicomio"
+	"github.com/amitbet/dicom/pkg/frame"
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/suyashkumar/dicom/pkg/tag"
+	"github.com/amitbet/dicom/pkg/tag"
 )
 
 func TestReadTag(t *testing.T) {

--- a/testdata/data_details.md
+++ b/testdata/data_details.md
@@ -13,12 +13,12 @@ The sub-bullets mention potentially interesting characteristics of the test file
 Some of the interesting characteristics may apply to more than one file, but may only
 be mentioned in one of them for brevity.
 
-* [1.dcm](1.dcm) (from [#77](https://github.com/suyashkumar/dicom/issues/77)) 
+* [1.dcm](1.dcm) (from [#77](https://github.com/amitbet/dicom/issues/77)) 
   * Modality: PET 
   * Native Pixel Data
   * Doubly Nested Sequences
   * Icon pixel data in addition to typical pixel data 
-* [2.dcm](2.dcm) (from [#77](https://github.com/suyashkumar/dicom/issues/77))
+* [2.dcm](2.dcm) (from [#77](https://github.com/amitbet/dicom/issues/77))
   * Modality: PET
   * Other items similar to 1.dcm
 * [3.dcm](3.dcm)

--- a/write.go
+++ b/write.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/suyashkumar/dicom/pkg/vrraw"
+	"github.com/amitbet/dicom/pkg/vrraw"
 
-	"github.com/suyashkumar/dicom/pkg/uid"
+	"github.com/amitbet/dicom/pkg/uid"
 
-	"github.com/suyashkumar/dicom/pkg/dicomio"
-	"github.com/suyashkumar/dicom/pkg/tag"
+	"github.com/amitbet/dicom/pkg/dicomio"
+	"github.com/amitbet/dicom/pkg/tag"
 )
 
 var (

--- a/write_test.go
+++ b/write_test.go
@@ -7,17 +7,17 @@ import (
 	"os"
 	"testing"
 
-	"github.com/suyashkumar/dicom/pkg/vrraw"
+	"github.com/amitbet/dicom/pkg/vrraw"
 
-	"github.com/suyashkumar/dicom/pkg/frame"
+	"github.com/amitbet/dicom/pkg/frame"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/suyashkumar/dicom/pkg/dicomio"
-	"github.com/suyashkumar/dicom/pkg/tag"
-	"github.com/suyashkumar/dicom/pkg/uid"
+	"github.com/amitbet/dicom/pkg/dicomio"
+	"github.com/amitbet/dicom/pkg/tag"
+	"github.com/amitbet/dicom/pkg/uid"
 )
 
 // TestWrite tests the write package by ensuring that it is consistent with the


### PR DESCRIPTION
This fix allows reading until EOF, without providing "bytesToRead", it keeps the previous Parse signature for backwards compatibility and creates a new ParseUntilEOF function which doesn't require the extra param.

This addresses #236.