### PR TITLE
allow for reading until EOF with the function ParseUntilEOF 

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -61,7 +61,7 @@ func Parse(in io.Reader, bytesToRead int64, frameChan chan *frame.Frame, opts ..
 }
 
 func ParseUntilEOF(in io.Reader, frameChan chan *frame.Frame, opts ...ParseOption) (Dataset, error) {
-	return parseInternal(in, LimitReadUntilEOF, frameChan, opts...)
+	return parseInternal(in, dicomio.LimitReadUntilEOF, frameChan, opts...)
 }
 
 // Parse parses the entire DICOM at the input io.Reader into a Dataset of DICOM Elements. Use this if you are

--- a/parse.go
+++ b/parse.go
@@ -36,7 +36,8 @@ import (
 )
 
 const (
-	magicWord = "DICM"
+	magicWord         = "DICM"
+	LimitReadUntilEOF = -9999
 )
 
 var (
@@ -60,7 +61,7 @@ func Parse(in io.Reader, bytesToRead int64, frameChan chan *frame.Frame, opts ..
 }
 
 func ParseUntilEOF(in io.Reader, frameChan chan *frame.Frame, opts ...ParseOption) (Dataset, error) {
-	return parseInternal(in, -1, frameChan, opts...)
+	return parseInternal(in, LimitReadUntilEOF, frameChan, opts...)
 }
 
 // Parse parses the entire DICOM at the input io.Reader into a Dataset of DICOM Elements. Use this if you are

--- a/parse.go
+++ b/parse.go
@@ -75,8 +75,12 @@ func parseInternal(in io.Reader, bytesToRead int64, frameChan chan *frame.Frame,
 		_, err := p.Next()
 		if err != nil {
 			if err.Error() == "EOF" {
+				// exiting on EOF
 				err = nil
+				break
 			}
+
+			// exit on error
 			return p.dataset, err
 		}
 	}

--- a/parse.go
+++ b/parse.go
@@ -36,8 +36,7 @@ import (
 )
 
 const (
-	magicWord         = "DICM"
-	LimitReadUntilEOF = -9999
+	magicWord = "DICM"
 )
 
 var (

--- a/parse.go
+++ b/parse.go
@@ -74,7 +74,7 @@ func parseInternal(in io.Reader, bytesToRead int64, frameChan chan *frame.Frame,
 	for !p.reader.rawReader.IsLimitExhausted() {
 		_, err := p.Next()
 		if err != nil {
-			if err.Error() == "EOF" {
+			if errors.Is(err, io.EOF) {
 				// exiting on EOF
 				err = nil
 				break

--- a/parse_internal_test.go
+++ b/parse_internal_test.go
@@ -1,0 +1,60 @@
+package dicom
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// TestParseUntilEOFConformsToParse runs both the dicom.ParseUntilEOF and the dicom.Parse APIs against each
+// testdata file and ensures the outputs are the same.
+// This test lives in parse_internal_test.go because this test cannot live in the dicom_test package, due
+// to some dependencies on internal valuesets for diffing.
+func TestParseUntilEOFConformsToParse(t *testing.T) {
+	files, err := ioutil.ReadDir("./testdata")
+	if err != nil {
+		t.Fatalf("unable to read testdata/: %v", err)
+	}
+	for _, f := range files {
+		f := f
+		if !f.IsDir() && strings.HasSuffix(f.Name(), ".dcm") {
+			t.Run(f.Name(), func(t *testing.T) {
+				t.Parallel()
+				// Read dataset with ParseUntilEOF
+				dcm := readTestdataFile(t, f.Name())
+				parse_eof_dataset, err := ParseUntilEOF(dcm, nil)
+				if err != nil {
+					t.Errorf("dicom.ParseUntilEOF(%s) unexpected error: %v", f.Name(), err)
+				}
+
+				// Read dataset with Parse
+				dcm2 := readTestdataFile(t, f.Name())
+				info, err := dcm2.Stat()
+				if err != nil {
+					t.Errorf("Unable to stat %s. Error: %v", f.Name(), err)
+				}
+				parse_dataset, err := Parse(dcm2, info.Size(), nil)
+				if err != nil {
+					t.Errorf("dicom.Parse(%s) unexpected error: %v", f.Name(), err)
+				}
+
+				// Ensure dataset read from ParseUntilEOF and Parse are the same.
+				if diff := cmp.Diff(parse_dataset, parse_eof_dataset, cmp.AllowUnexported(allValues...)); diff != "" {
+					t.Errorf("dicom.Parse and dicom.ParseUntilEOF do not result in the same dataset. diff: %v", diff)
+				}
+			})
+		}
+	}
+}
+
+func readTestdataFile(t *testing.T, name string) *os.File {
+	dcm, err := os.Open("./testdata/" + name)
+	if err != nil {
+		t.Errorf("Unable to open %s. Error: %v", name, err)
+	}
+	t.Cleanup(func() { dcm.Close() })
+	return dcm
+}

--- a/parse_test.go
+++ b/parse_test.go
@@ -45,6 +45,32 @@ func TestParse(t *testing.T) {
 	}
 }
 
+func TestParseUntilEOF(t *testing.T) {
+	files, err := ioutil.ReadDir("./testdata")
+	if err != nil {
+		t.Fatalf("unable to read testdata/: %v", err)
+	}
+	for _, f := range files {
+		if !f.IsDir() && strings.HasSuffix(f.Name(), ".dcm") {
+			t.Run(f.Name(), func(t *testing.T) {
+				dcm, err := os.Open("./testdata/" + f.Name())
+				if err != nil {
+					t.Errorf("Unable to open %s. Error: %v", f.Name(), err)
+				}
+				defer dcm.Close()
+
+				if err != nil {
+					t.Errorf("Unable to stat %s. Error: %v", f.Name(), err)
+				}
+				_, err = dicom.ParseUntilEOF(dcm, nil)
+				if err != nil {
+					t.Errorf("dicom.Parse(%s) unexpected error: %v", f.Name(), err)
+				}
+			})
+		}
+	}
+}
+
 // TestNewParserSkipMetadataReadOnNewParserInit tests that NewParser with the SkipMetadataReadOnNewParserInit option
 // parses the specified dataset but not its header metadata.
 func TestNewParserSkipMetadataReadOnNewParserInit(t *testing.T) {

--- a/pkg/dicomio/reader.go
+++ b/pkg/dicomio/reader.go
@@ -218,7 +218,8 @@ func (r *reader) PopLimit() {
 }
 
 func (r *reader) IsLimitExhausted() bool {
-	return r.BytesLeftUntilLimit() <= 0
+	// if limit < 0 than we should read until EOF
+	return (r.BytesLeftUntilLimit() <= 0 || r.limit < 0)
 }
 
 func (r *reader) SetTransferSyntax(bo binary.ByteOrder, implicit bool) {

--- a/pkg/dicomio/reader.go
+++ b/pkg/dicomio/reader.go
@@ -99,7 +99,7 @@ func NewReader(in *bufio.Reader, bo binary.ByteOrder, limit int64) Reader {
 }
 
 func (r *reader) BytesLeftUntilLimit() int64 {
-	if r.limit < 0 {
+	if r.limit == LimitReadUntilEOF {
 		return math.MaxInt64
 	}
 	return r.limit - r.bytesRead

--- a/pkg/dicomio/reader.go
+++ b/pkg/dicomio/reader.go
@@ -20,6 +20,8 @@ var (
 	ErrorInsufficientBytesLeft = errors.New("not enough bytes left until buffer limit to complete this operation")
 )
 
+// LimitReadUntilEOF is a special dicomio.Reader limit indicating that there is no hard limit and the
+// Reader should read until EOF. 
 const LimitReadUntilEOF = -9999
 
 // Reader provides common functionality for reading underlying DICOM data.

--- a/read.go
+++ b/read.go
@@ -50,6 +50,14 @@ func (r *reader) readTag() (*tag.Tag, error) {
 	if gerr == nil && eerr == nil {
 		return &tag.Tag{Group: group, Element: element}, nil
 	}
+	if gerr != nil || eerr != nil {
+		if gerr.Error() == "EOF" {
+			return nil, gerr
+		}
+		if eerr.Error() == "EOF" {
+			return nil, eerr
+		}
+	}
 	return nil, fmt.Errorf("error reading tag: %v %v", gerr, eerr)
 }
 

--- a/read.go
+++ b/read.go
@@ -50,13 +50,13 @@ func (r *reader) readTag() (*tag.Tag, error) {
 	if gerr == nil && eerr == nil {
 		return &tag.Tag{Group: group, Element: element}, nil
 	}
-	if gerr != nil || eerr != nil {
-		if gerr.Error() == "EOF" {
-			return nil, gerr
-		}
-		if eerr.Error() == "EOF" {
-			return nil, eerr
-		}
+	// If the error is an io.EOF, return the error directly instead of the compound error later.
+	// Once we target go1.20 we can use errors.Join: https://pkg.go.dev/errors#Join
+	if errors.Is(gerr, io.EOF) {
+		return nil, gerr
+	}
+	if errors.Is(eerr, io.EOF) {
+		return nil, eerr
 	}
 	return nil, fmt.Errorf("error reading tag: %v %v", gerr, eerr)
 }


### PR DESCRIPTION
The -new- PR for this from another branch.

This fix allows reading until EOF, without providing "bytesToRead", it keeps the previous Parse signature for backwards compatibility and creates a new ParseUntilEOF function which doesn't require the extra param.