### PR TITLE
fix Application Entity (AE) value parsing

### DIFF
--- a/write.go
+++ b/write.go
@@ -471,7 +471,7 @@ func writeStrings(w dicomio.Writer, values []string, vr string) error {
 		switch vr {
 		case vrraw.DateTime, vrraw.LongString, vrraw.LongText, vrraw.PersonName,
 			vrraw.ShortString, vrraw.ShortText, vrraw.UnlimitedText,
-			vrraw.DecimalString, vrraw.CodeString, vrraw.Time,
+			vrraw.DecimalString, vrraw.CodeString, vrraw.Time, vrraw.ApplicationEntity,
 			vrraw.IntegerString, vrraw.Unknown:
 			if err := w.WriteString(" "); err != nil { // https://dicom.nema.org/medical/dicom/current/output/html/part05.html#sect_6.2
 				return err


### PR DESCRIPTION
fix #275 

Values with VRs constructed of character strings, except in the case of the VR UI, shall be padded with SPACE characters (20H, in the Default Character Repertoire) when necessary to achieve even length. 

AE is no exception.

TYVM @suyashkumar :)