### PR TITLE
Log and return to ensure defers are still called in example dicomutil.

### DIFF
--- a/cmd/dicomutil/main.go
+++ b/cmd/dicomutil/main.go
@@ -55,7 +55,6 @@ func main() {
 		}
 
 		var ds *dicom.Dataset
-		var err error
 		if *extractImagesStream {
 			ds, err = parseWithStreaming(f, info.Size())
 			if err != nil {
@@ -123,7 +122,7 @@ func parseWithStreaming(in io.Reader, size int64) (*dicom.Dataset, error) {
 	}
 	wg.Wait()
 
-	return &ds
+	return &ds, nil
 
 }
 


### PR DESCRIPTION
Where appropriate, this calls log.Infof along with a return instead of log.Fatalf to ensure defered functions are actually run in those exit scenarios. 

Looking at dicomutil, it could probably use some improvements and a refactor as well in general as an example program. 