### PR TITLE
Add Dataset & Element equality methods, greatly speeding up tests that rely on dataset comparisons.

### DIFF
--- a/cmd/dicomutil/main.go
+++ b/cmd/dicomutil/main.go
@@ -186,6 +186,6 @@ func generateImage(fr *frame.Frame, frameIndex int, frameSuffix string, wg *sync
 func writePixelDataElement(e *dicom.Element, suffix string) {
 	imageInfo := e.Value.GetValue().(dicom.PixelDataInfo)
 	for idx, f := range imageInfo.Frames {
-		generateImage(&f, idx, suffix, nil)
+		generateImage(f, idx, suffix, nil)
 	}
 }

--- a/dataset.go
+++ b/dataset.go
@@ -190,7 +190,12 @@ func (d *Dataset) String() string {
 	return b.String()
 }
 
+// Equals returns true if this Dataset equals the provided target Dataset,
+// otherwise false.
 func (d *Dataset) Equals(target *Dataset) bool {
+	if target == nil {
+		return d == target
+	}
 	for idx, e := range d.Elements {
 		if !e.Equals(target.Elements[idx]) {
 			return false

--- a/dataset.go
+++ b/dataset.go
@@ -190,6 +190,15 @@ func (d *Dataset) String() string {
 	return b.String()
 }
 
+func (d *Dataset) Equals(target *Dataset) bool {
+	for idx, e := range d.Elements {
+		if !e.Equals(target.Elements[idx]) {
+			return false
+		}
+	}
+	return true
+}
+
 type elementWithLevel struct {
 	e *Element
 	// l represents the nesting level of the Element

--- a/dataset.go
+++ b/dataset.go
@@ -193,7 +193,7 @@ func (d *Dataset) String() string {
 // Equals returns true if this Dataset equals the provided target Dataset,
 // otherwise false.
 func (d *Dataset) Equals(target *Dataset) bool {
-	if target == nil {
+	if target == nil || d == nil {
 		return d == target
 	}
 	for idx, e := range d.Elements {

--- a/element.go
+++ b/element.go
@@ -25,7 +25,12 @@ type Element struct {
 	Value                  Value      `json:"value"`
 }
 
+// Equals returns true if this Element equals the provided target Element,
+// otherwise false.
 func (e *Element) Equals(target *Element) bool {
+	if target == nil {
+		return e == target
+	}
 	if !e.Tag.Equals(target.Tag) ||
 		e.RawValueRepresentation != target.RawValueRepresentation ||
 		e.ValueLength != target.ValueLength ||

--- a/element.go
+++ b/element.go
@@ -28,7 +28,7 @@ type Element struct {
 // Equals returns true if this Element equals the provided target Element,
 // otherwise false.
 func (e *Element) Equals(target *Element) bool {
-	if target == nil {
+	if target == nil || e == nil {
 		return e == target
 	}
 	if !e.Tag.Equals(target.Tag) ||

--- a/element_test.go
+++ b/element_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/suyashkumar/dicom/pkg/frame"
 
 	"github.com/suyashkumar/dicom/pkg/tag"
 )
@@ -142,5 +143,272 @@ func TestNewValue_UnexpectedType(t *testing.T) {
 	_, err := NewValue(data)
 	if err != ErrorUnexpectedDataType {
 		t.Errorf("NewValue(%v) expected an error. got: %v, want: %v", data, err, ErrorUnexpectedDataType)
+	}
+}
+
+func TestElement_Equals(t *testing.T) {
+	// Some general sanity checks below, not every possible case is included.
+	cases := []struct {
+		name      string
+		a         *Element
+		b         *Element
+		wantEqual bool
+	}{
+		{
+			name:      "EqualFloats",
+			a:         mustNewElement(tag.FloatingPointValue, []float64{1.23, 4.40, 5.50}),
+			b:         mustNewElement(tag.FloatingPointValue, []float64{1.23, 4.40, 5.50}),
+			wantEqual: true,
+		},
+		{
+			name:      "UnequalLenFloats",
+			a:         mustNewElement(tag.FloatingPointValue, []float64{1.23, 4.40}),
+			b:         mustNewElement(tag.FloatingPointValue, []float64{1.23, 4.40, 5.50}),
+			wantEqual: false,
+		},
+		{
+			name:      "UnequalFloats",
+			a:         mustNewElement(tag.FloatingPointValue, []float64{1.23, 4.40, 10.1}),
+			b:         mustNewElement(tag.FloatingPointValue, []float64{1.23, 4.40, 5.50}),
+			wantEqual: false,
+		},
+		{
+			name:      "EqualInts",
+			a:         mustNewElement(tag.Rows, []int{1, 2, 3}),
+			b:         mustNewElement(tag.Rows, []int{1, 2, 3}),
+			wantEqual: true,
+		},
+		{
+			name:      "UnequalInts",
+			a:         mustNewElement(tag.Rows, []int{1, 2, 6}),
+			b:         mustNewElement(tag.Rows, []int{1, 2, 3}),
+			wantEqual: false,
+		},
+		{
+			name:      "UnequalLenInts",
+			a:         mustNewElement(tag.Rows, []int{1, 6}),
+			b:         mustNewElement(tag.Rows, []int{1, 2, 3}),
+			wantEqual: false,
+		},
+		{
+			name:      "EqualBytes",
+			a:         mustNewElement(tag.AirCounts, []byte{1, 2, 3}),
+			b:         mustNewElement(tag.AirCounts, []byte{1, 2, 3}),
+			wantEqual: true,
+		},
+		{
+			name:      "UnequalBytes",
+			a:         mustNewElement(tag.AirCounts, []byte{1, 2, 4}),
+			b:         mustNewElement(tag.AirCounts, []byte{1, 2, 3}),
+			wantEqual: false,
+		},
+		{
+			name:      "UnequalLenBytes",
+			a:         mustNewElement(tag.AirCounts, []byte{1, 2, 3}),
+			b:         mustNewElement(tag.AirCounts, []byte{1, 2}),
+			wantEqual: false,
+		},
+		{
+			name:      "EqualStrings",
+			a:         mustNewElement(tag.PatientName, []string{"John", "Smith"}),
+			b:         mustNewElement(tag.PatientName, []string{"John", "Smith"}),
+			wantEqual: true,
+		},
+		{
+			name:      "UnequalStrings",
+			a:         mustNewElement(tag.PatientName, []string{"John", "Doe"}),
+			b:         mustNewElement(tag.PatientName, []string{"John", "Smith"}),
+			wantEqual: false,
+		},
+		{
+			name:      "UnequalLenStrings",
+			a:         mustNewElement(tag.PatientName, []string{"John"}),
+			b:         mustNewElement(tag.PatientName, []string{"John", "Smith"}),
+			wantEqual: false,
+		},
+		{
+			name: "EqualNativePixelData",
+			a: mustNewElement(tag.PixelData, PixelDataInfo{
+				IsEncapsulated: false,
+				Frames: []*frame.Frame{
+					{
+						Encapsulated: false,
+						NativeData: frame.NativeFrame{
+							BitsPerSample: 8,
+							Rows:          2,
+							Cols:          2,
+							Data:          [][]int{{1}, {2}, {3}, {4}},
+						},
+					},
+				},
+			}),
+			b: mustNewElement(tag.PixelData, PixelDataInfo{
+				IsEncapsulated: false,
+				Frames: []*frame.Frame{
+					{
+						Encapsulated: false,
+						NativeData: frame.NativeFrame{
+							BitsPerSample: 8,
+							Rows:          2,
+							Cols:          2,
+							Data:          [][]int{{1}, {2}, {3}, {4}},
+						},
+					},
+				},
+			}),
+			wantEqual: true,
+		},
+		{
+			name: "UnequalNativePixelData",
+			a: mustNewElement(tag.PixelData, PixelDataInfo{
+				IsEncapsulated: false,
+				Frames: []*frame.Frame{
+					{
+						Encapsulated: false,
+						NativeData: frame.NativeFrame{
+							BitsPerSample: 8,
+							Rows:          2,
+							Cols:          2,
+							Data:          [][]int{{1}, {2}, {3}, {6}},
+						},
+					},
+				},
+			}),
+			b: mustNewElement(tag.PixelData, PixelDataInfo{
+				IsEncapsulated: false,
+				Frames: []*frame.Frame{
+					{
+						Encapsulated: false,
+						NativeData: frame.NativeFrame{
+							BitsPerSample: 8,
+							Rows:          2,
+							Cols:          2,
+							Data:          [][]int{{1}, {2}, {3}, {4}},
+						},
+					},
+				},
+			}),
+			wantEqual: false,
+		},
+		{
+			name: "EqualSequences",
+			a: makeSequenceElement(tag.AddOtherSequence, [][]*Element{
+				// Item 1.
+				{
+					{
+						Tag:                    tag.PatientName,
+						ValueRepresentation:    tag.VRStringList,
+						RawValueRepresentation: "PN",
+						Value:                  &stringsValue{value: []string{"Bob", "Jones"}},
+					},
+				},
+				// Item 2.
+				{
+					{
+						Tag:                    tag.PatientName,
+						ValueRepresentation:    tag.VRStringList,
+						RawValueRepresentation: "PN",
+						Value:                  &stringsValue{value: []string{"Bob", "Jones"}},
+					},
+					{
+						Tag:                    tag.Rows,
+						ValueRepresentation:    tag.VRUInt16List,
+						RawValueRepresentation: "US",
+						Value:                  &intsValue{value: []int{100}},
+					},
+				},
+			}),
+			b: makeSequenceElement(tag.AddOtherSequence, [][]*Element{
+				// Item 1.
+				{
+					{
+						Tag:                    tag.PatientName,
+						ValueRepresentation:    tag.VRStringList,
+						RawValueRepresentation: "PN",
+						Value:                  &stringsValue{value: []string{"Bob", "Jones"}},
+					},
+				},
+				// Item 2.
+				{
+					{
+						Tag:                    tag.PatientName,
+						ValueRepresentation:    tag.VRStringList,
+						RawValueRepresentation: "PN",
+						Value:                  &stringsValue{value: []string{"Bob", "Jones"}},
+					},
+					{
+						Tag:                    tag.Rows,
+						ValueRepresentation:    tag.VRUInt16List,
+						RawValueRepresentation: "US",
+						Value:                  &intsValue{value: []int{100}},
+					},
+				},
+			}),
+			wantEqual: true,
+		},
+		{
+			name: "UnequalSequences",
+			a: makeSequenceElement(tag.AddOtherSequence, [][]*Element{
+				// Item 1.
+				{
+					{
+						Tag:                    tag.PatientName,
+						ValueRepresentation:    tag.VRStringList,
+						RawValueRepresentation: "PN",
+						//	Smith instead of Jones below causes inequality.
+						Value: &stringsValue{value: []string{"Bob", "Smith"}},
+					},
+				},
+				// Item 2.
+				{
+					{
+						Tag:                    tag.PatientName,
+						ValueRepresentation:    tag.VRStringList,
+						RawValueRepresentation: "PN",
+						Value:                  &stringsValue{value: []string{"Bob", "Jones"}},
+					},
+					{
+						Tag:                    tag.Rows,
+						ValueRepresentation:    tag.VRUInt16List,
+						RawValueRepresentation: "US",
+						Value:                  &intsValue{value: []int{100}},
+					},
+				},
+			}),
+			b: makeSequenceElement(tag.AddOtherSequence, [][]*Element{
+				// Item 1.
+				{
+					{
+						Tag:                    tag.PatientName,
+						ValueRepresentation:    tag.VRStringList,
+						RawValueRepresentation: "PN",
+						Value:                  &stringsValue{value: []string{"Bob", "Jones"}},
+					},
+				},
+				// Item 2.
+				{
+					{
+						Tag:                    tag.PatientName,
+						ValueRepresentation:    tag.VRStringList,
+						RawValueRepresentation: "PN",
+						Value:                  &stringsValue{value: []string{"Bob", "Jones"}},
+					},
+					{
+						Tag:                    tag.Rows,
+						ValueRepresentation:    tag.VRUInt16List,
+						RawValueRepresentation: "US",
+						Value:                  &intsValue{value: []int{100}},
+					},
+				},
+			}),
+			wantEqual: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.a.Equals(tc.b) != tc.wantEqual {
+				t.Errorf("Element.Equals(%v, %v) != %v", tc.a, tc.b, tc.wantEqual)
+			}
+		})
 	}
 }

--- a/element_test.go
+++ b/element_test.go
@@ -155,6 +155,18 @@ func TestElement_Equals(t *testing.T) {
 		wantEqual bool
 	}{
 		{
+			name:      "EqualNilElements",
+			a:         nil,
+			b:         nil,
+			wantEqual: true,
+		},
+		{
+			name:      "UnequalNilElement",
+			a:         nil,
+			b:         mustNewElement(tag.FloatingPointValue, []float64{1.23}),
+			wantEqual: false,
+		},
+		{
 			name:      "EqualFloats",
 			a:         mustNewElement(tag.FloatingPointValue, []float64{1.23, 4.40, 5.50}),
 			b:         mustNewElement(tag.FloatingPointValue, []float64{1.23, 4.40, 5.50}),

--- a/parse_internal_test.go
+++ b/parse_internal_test.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-
-	"github.com/google/go-cmp/cmp"
 )
 
 // TestParseUntilEOFConformsToParse runs both the dicom.ParseUntilEOF and the dicom.Parse APIs against each
@@ -42,9 +40,10 @@ func TestParseUntilEOFConformsToParse(t *testing.T) {
 				}
 
 				// Ensure dataset read from ParseUntilEOF and Parse are the same.
-				if diff := cmp.Diff(parse_dataset, parse_eof_dataset, cmp.AllowUnexported(allValues...)); diff != "" {
-					t.Errorf("dicom.Parse and dicom.ParseUntilEOF do not result in the same dataset. diff: %v", diff)
+				if !parse_dataset.Equals(&parse_eof_dataset) {
+					t.Errorf("dicom.Parse and dicom.ParseUntilEOF do not result in the same dataset.\nParse Dataset: %v\n\n\nParse EOF Dataset: %v", parse_dataset, parse_eof_dataset)
 				}
+
 			})
 		}
 	}

--- a/pkg/frame/encapsulated.go
+++ b/pkg/frame/encapsulated.go
@@ -35,6 +35,8 @@ func (e *EncapsulatedFrame) GetImage() (image.Image, error) {
 	return jpeg.Decode(bytes.NewReader(e.Data))
 }
 
+// Equals returns true if this frame equals the provided target frame, otherwise
+// false.
 func (e *EncapsulatedFrame) Equals(target *EncapsulatedFrame) bool {
 	if !bytes.Equal(e.Data, target.Data) {
 		return false

--- a/pkg/frame/encapsulated.go
+++ b/pkg/frame/encapsulated.go
@@ -34,3 +34,10 @@ func (e *EncapsulatedFrame) GetImage() (image.Image, error) {
 	// there.
 	return jpeg.Decode(bytes.NewReader(e.Data))
 }
+
+func (e *EncapsulatedFrame) Equals(target *EncapsulatedFrame) bool {
+	if !bytes.Equal(e.Data, target.Data) {
+		return false
+	}
+	return true
+}

--- a/pkg/frame/frame.go
+++ b/pkg/frame/frame.go
@@ -71,3 +71,16 @@ func (f *Frame) GetImage() (image.Image, error) {
 	}
 	return f.NativeData.GetImage()
 }
+
+func (f *Frame) Equals(target *Frame) bool {
+	if f.Encapsulated != target.Encapsulated {
+		return false
+	}
+	if f.Encapsulated && !f.EncapsulatedData.Equals(&target.EncapsulatedData) {
+		return false
+	}
+	if !f.Encapsulated && !f.NativeData.Equals(&target.NativeData) {
+		return false
+	}
+	return true
+}

--- a/pkg/frame/frame.go
+++ b/pkg/frame/frame.go
@@ -72,7 +72,12 @@ func (f *Frame) GetImage() (image.Image, error) {
 	return f.NativeData.GetImage()
 }
 
+// Equals returns true if this frame equals the provided target frame, otherwise
+// false.
 func (f *Frame) Equals(target *Frame) bool {
+	if target == nil {
+		return f == target
+	}
 	if f.Encapsulated != target.Encapsulated {
 		return false
 	}

--- a/pkg/frame/frame.go
+++ b/pkg/frame/frame.go
@@ -75,7 +75,7 @@ func (f *Frame) GetImage() (image.Image, error) {
 // Equals returns true if this frame equals the provided target frame, otherwise
 // false.
 func (f *Frame) Equals(target *Frame) bool {
-	if target == nil {
+	if target == nil || f == nil {
 		return f == target
 	}
 	if f.Encapsulated != target.Encapsulated {

--- a/pkg/frame/native.go
+++ b/pkg/frame/native.go
@@ -40,7 +40,12 @@ func (n *NativeFrame) GetImage() (image.Image, error) {
 	return i, nil
 }
 
+// Equals returns true if this frame equals the provided target frame, otherwise
+// false.
 func (n *NativeFrame) Equals(target *NativeFrame) bool {
+	if target == nil {
+		return n == target
+	}
 	if n.Rows != target.Rows ||
 		n.Cols != target.Cols ||
 		n.BitsPerSample != n.BitsPerSample {

--- a/pkg/frame/native.go
+++ b/pkg/frame/native.go
@@ -43,7 +43,7 @@ func (n *NativeFrame) GetImage() (image.Image, error) {
 // Equals returns true if this frame equals the provided target frame, otherwise
 // false.
 func (n *NativeFrame) Equals(target *NativeFrame) bool {
-	if target == nil {
+	if target == nil || n == nil {
 		return n == target
 	}
 	if n.Rows != target.Rows ||

--- a/pkg/frame/native.go
+++ b/pkg/frame/native.go
@@ -39,3 +39,19 @@ func (n *NativeFrame) GetImage() (image.Image, error) {
 	}
 	return i, nil
 }
+
+func (n *NativeFrame) Equals(target *NativeFrame) bool {
+	if n.Rows != target.Rows ||
+		n.Cols != target.Cols ||
+		n.BitsPerSample != n.BitsPerSample {
+		return false
+	}
+	for pixIdx, pix := range n.Data {
+		for valIdx, val := range pix {
+			if val != target.Data[pixIdx][valIdx] {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/read.go
+++ b/read.go
@@ -258,7 +258,7 @@ func (r *reader) readPixelData(vl uint32, d *Dataset, fc chan<- *frame.Frame) (V
 				fc <- &f
 			}
 
-			image.Frames = append(image.Frames, f)
+			image.Frames = append(image.Frames, &f)
 		}
 		image.IntentionallySkipped = r.opts.skipPixelData
 		return &pixelDataValue{PixelDataInfo: image}, nil
@@ -358,7 +358,7 @@ func makeErrorPixelData(reader io.Reader, vl uint32, fc chan<- *frame.Frame, par
 	}
 	image := PixelDataInfo{
 		ParseErr: parseErr,
-		Frames:   []frame.Frame{f},
+		Frames:   []*frame.Frame{&f},
 	}
 	return &image, nil
 }
@@ -437,7 +437,7 @@ func (r *reader) readNativeFrames(parsedData *Dataset, fc chan<- *frame.Frame, v
 	image := PixelDataInfo{
 		IsEncapsulated: false,
 	}
-	image.Frames = make([]frame.Frame, nFrames)
+	image.Frames = make([]*frame.Frame, nFrames)
 	bo := r.rawReader.ByteOrder()
 	pixelBuf := make([]byte, bytesAllocated)
 	for frameIdx := 0; frameIdx < nFrames; frameIdx++ {
@@ -482,7 +482,7 @@ func (r *reader) readNativeFrames(parsedData *Dataset, fc chan<- *frame.Frame, v
 				currentFrame.NativeData.Data[pixel] = buf[pixel*samplesPerPixel : (pixel+1)*samplesPerPixel]
 			}
 		}
-		image.Frames[frameIdx] = currentFrame
+		image.Frames[frameIdx] = &currentFrame
 		if fc != nil {
 			fc <- &currentFrame // write the current frame to the frame channel
 		}

--- a/read_test.go
+++ b/read_test.go
@@ -229,7 +229,7 @@ func TestReadNativeFrames(t *testing.T) {
 			data: []uint16{1, 2, 3, 4, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 			expectedPixelData: &PixelDataInfo{
 				IsEncapsulated: false,
-				Frames: []frame.Frame{
+				Frames: []*frame.Frame{
 					{
 						Encapsulated: false,
 						NativeData: frame.NativeFrame{
@@ -255,7 +255,7 @@ func TestReadNativeFrames(t *testing.T) {
 			data: []uint16{1, 2, 3, 2, 1, 2, 3, 2, 1, 2, 3, 0},
 			expectedPixelData: &PixelDataInfo{
 				IsEncapsulated: false,
-				Frames: []frame.Frame{
+				Frames: []*frame.Frame{
 					{
 						Encapsulated: false,
 						NativeData: frame.NativeFrame{
@@ -299,7 +299,7 @@ func TestReadNativeFrames(t *testing.T) {
 			data: []uint16{1, 2, 3, 2, 1, 2, 3, 2, 1, 2, 3, 2, 1, 2, 3, 5},
 			expectedPixelData: &PixelDataInfo{
 				IsEncapsulated: false,
-				Frames: []frame.Frame{
+				Frames: []*frame.Frame{
 					{
 						Encapsulated: false,
 						NativeData: frame.NativeFrame{
@@ -360,7 +360,7 @@ func TestReadNativeFrames(t *testing.T) {
 			data: []uint16{1, 2, 3, 2, 1, 2, 3, 2, 1, 2, 3, 2, 1, 2, 3, 2, 2},
 			expectedPixelData: &PixelDataInfo{
 				ParseErr: ErrorMismatchPixelDataLength,
-				Frames: []frame.Frame{
+				Frames: []*frame.Frame{
 					{
 						EncapsulatedData: frame.EncapsulatedFrame{
 							Data: []byte{1, 0, 2, 0, 3, 0, 2, 0, 1, 0, 2, 0, 3, 0, 2, 0, 1, 0, 2, 0, 3, 0, 2, 0, 1, 0, 2, 0, 3, 0, 2, 0, 2, 0},
@@ -408,7 +408,7 @@ func TestReadNativeFrames(t *testing.T) {
 			dataBytes: []byte{11, 12, 13, 21, 22, 23, 31, 32, 33, 11, 12, 13, 21, 22, 23, 31, 32, 33, 11, 12, 13, 21, 22, 23, 31, 32, 33, 0}, // there is a 28th byte to make total value length even, as required by DICOM spec
 			expectedPixelData: &PixelDataInfo{
 				IsEncapsulated: false,
-				Frames: []frame.Frame{
+				Frames: []*frame.Frame{
 					{
 						Encapsulated: false,
 						NativeData: frame.NativeFrame{
@@ -453,7 +453,7 @@ func TestReadNativeFrames(t *testing.T) {
 			dataBytes: []byte{1, 2, 3, 1, 2, 3, 1, 2, 3, 0}, // 10th byte to make total value length even
 			expectedPixelData: &PixelDataInfo{
 				IsEncapsulated: false,
-				Frames: []frame.Frame{
+				Frames: []*frame.Frame{
 					{
 						Encapsulated: false,
 						NativeData: frame.NativeFrame{
@@ -761,7 +761,7 @@ func makeEncapsulatedSequence(t *testing.T) []byte {
 	buf := &bytes.Buffer{}
 	w := dicomio.NewWriter(buf, binary.LittleEndian, true)
 
-	writePixelData(w, tag.PixelData, &pixelDataValue{PixelDataInfo{IsEncapsulated: true, Frames: []frame.Frame{
+	writePixelData(w, tag.PixelData, &pixelDataValue{PixelDataInfo{IsEncapsulated: true, Frames: []*frame.Frame{
 		{
 			Encapsulated: true,
 			EncapsulatedData: frame.EncapsulatedFrame{
@@ -795,7 +795,7 @@ func TestReadNativeFrames_OneBitAllocated(t *testing.T) {
 			data: []byte{0b00010111, 0b10010111},
 			expectedPixelData: &PixelDataInfo{
 				IsEncapsulated: false,
-				Frames: []frame.Frame{
+				Frames: []*frame.Frame{
 					{
 						Encapsulated: false,
 						NativeData: frame.NativeFrame{
@@ -822,7 +822,7 @@ func TestReadNativeFrames_OneBitAllocated(t *testing.T) {
 			data: []byte{0b00010111, 0b10010111},
 			expectedPixelData: &PixelDataInfo{
 				IsEncapsulated: false,
-				Frames: []frame.Frame{
+				Frames: []*frame.Frame{
 					{
 						Encapsulated: false,
 						NativeData: frame.NativeFrame{

--- a/write_test.go
+++ b/write_test.go
@@ -286,7 +286,7 @@ func TestWrite(t *testing.T) {
 				mustNewElement(tag.SamplesPerPixel, []int{1}),
 				mustNewElement(tag.PixelData, PixelDataInfo{
 					IsEncapsulated: false,
-					Frames: []frame.Frame{
+					Frames: []*frame.Frame{
 						{
 							Encapsulated: false,
 							NativeData: frame.NativeFrame{
@@ -316,7 +316,7 @@ func TestWrite(t *testing.T) {
 				mustNewElement(tag.SamplesPerPixel, []int{1}),
 				mustNewElement(tag.PixelData, PixelDataInfo{
 					IsEncapsulated: false,
-					Frames: []frame.Frame{
+					Frames: []*frame.Frame{
 						{
 							Encapsulated: false,
 							NativeData: frame.NativeFrame{
@@ -344,7 +344,7 @@ func TestWrite(t *testing.T) {
 				mustNewElement(tag.SamplesPerPixel, []int{1}),
 				mustNewElement(tag.PixelData, PixelDataInfo{
 					IsEncapsulated: false,
-					Frames: []frame.Frame{
+					Frames: []*frame.Frame{
 						{
 							Encapsulated: false,
 							NativeData: frame.NativeFrame{
@@ -372,7 +372,7 @@ func TestWrite(t *testing.T) {
 				mustNewElement(tag.SamplesPerPixel, []int{2}),
 				mustNewElement(tag.PixelData, PixelDataInfo{
 					IsEncapsulated: false,
-					Frames: []frame.Frame{
+					Frames: []*frame.Frame{
 						{
 							Encapsulated: false,
 							NativeData: frame.NativeFrame{
@@ -405,7 +405,7 @@ func TestWrite(t *testing.T) {
 				mustNewElement(tag.BitsAllocated, []int{8}),
 				setUndefinedLength(mustNewElement(tag.PixelData, PixelDataInfo{
 					IsEncapsulated: true,
-					Frames: []frame.Frame{
+					Frames: []*frame.Frame{
 						{
 							Encapsulated:     true,
 							EncapsulatedData: frame.EncapsulatedFrame{Data: []byte{1, 2, 3, 4}},
@@ -426,7 +426,7 @@ func TestWrite(t *testing.T) {
 				mustNewElement(tag.BitsAllocated, []int{8}),
 				setUndefinedLength(mustNewElement(tag.PixelData, PixelDataInfo{
 					IsEncapsulated: true,
-					Frames: []frame.Frame{
+					Frames: []*frame.Frame{
 						{
 							Encapsulated:     true,
 							EncapsulatedData: frame.EncapsulatedFrame{Data: []byte{1, 2, 3, 4}},


### PR DESCRIPTION
This change introduces well-defined equality methods for `Dataset`, `Element`, and some other data structures. This greatly speeds up tests that rely on checking equality of datasets (that previously needed reflection). For example, it reduces the total test suite from `1m24s` to `10s` on GitHub actions (mostly due to one test). These methods may also be of use to library users.

However, this does mean that if new fields are added to any of these structs it is important for the `Equals` method to be updated as well. For now this will be enforced during code review (helped by the fact most of these structs should not fail often), but we should investigate lint rules or some auto-generated reflection based tests that can help catch when this doesn't happen (see #281).  

This change also makes a change to rely on pointers for []*frame.Frame in the PixelDataInfo.

<img width="1289" alt="Screenshot 2023-08-26 at 7 04 33 PM" src="https://github.com/suyashkumar/dicom/assets/6299853/399fc90e-8d27-457c-b3ab-8a3130becae5">

<img width="1628" alt="Screenshot 2023-08-26 at 7 05 02 PM" src="https://github.com/suyashkumar/dicom/assets/6299853/c27dfbdd-9aac-49ff-901d-d9000e5b70d5">
