### PR TITLE
Remove Reader interface in favor of using the struct directly, use writer struct pointer for consistency

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -219,7 +219,7 @@ func (p *Parser) GetMetadata() Dataset {
 	return p.metadata
 }
 
-// SetTransferSyntax sets the transfer syntax for the underlying dicomio.Reader.
+// SetTransferSyntax sets the transfer syntax for the underlying *dicomio.Reader.
 func (p *Parser) SetTransferSyntax(bo binary.ByteOrder, implicit bool) {
 	p.reader.rawReader.SetTransferSyntax(bo, implicit)
 }

--- a/pkg/dicomio/writer.go
+++ b/pkg/dicomio/writer.go
@@ -14,8 +14,8 @@ type Writer struct {
 }
 
 // NewWriter initializes and returns a Writer.
-func NewWriter(out io.Writer, bo binary.ByteOrder, implicit bool) Writer {
-	return Writer{
+func NewWriter(out io.Writer, bo binary.ByteOrder, implicit bool) *Writer {
+	return &Writer{
 		out:      out,
 		bo:       bo,
 		implicit: implicit,

--- a/read.go
+++ b/read.go
@@ -34,12 +34,12 @@ var (
 )
 
 // reader is responsible for mid-level dicom parsing capabilities, like
-// reading tags, VRs, and elements from the low-level dicomio.Reader dicom data.
+// reading tags, VRs, and elements from the low-level *dicomio.Reader dicom data.
 // TODO(suyashkumar): consider revisiting naming of this struct "reader" as it
-// interplays with the rawReader dicomio.Reader. We could consider combining
-// them, or embedding the dicomio.Reader struct into reader.
+// interplays with the rawReader *dicomio.Reader. We could consider combining
+// them, or embedding the *dicomio.Reader struct into reader.
 type reader struct {
-	rawReader dicomio.Reader
+	rawReader *dicomio.Reader
 	opts      parseOptSet
 }
 
@@ -315,7 +315,7 @@ func getNthBit(data byte, n int) int {
 	return 0
 }
 
-func fillBufferSingleBitAllocated(pixelData []int, d dicomio.Reader, bo binary.ByteOrder) error {
+func fillBufferSingleBitAllocated(pixelData []int, d *dicomio.Reader, bo binary.ByteOrder) error {
 	debug.Logf("len of pixeldata: %d", len(pixelData))
 	if len(pixelData)%8 > 0 {
 		return errors.New("when bitsAllocated is 1, we can't read a number of samples that is not a multiple of 8")

--- a/read_test.go
+++ b/read_test.go
@@ -915,7 +915,7 @@ func BenchmarkReadNativeFrames(b *testing.B) {
 	}
 }
 
-func buildReadNativeFramesInput(rows, cols, numFrames, samplesPerPixel int, b *testing.B) (*Dataset, dicomio.Reader) {
+func buildReadNativeFramesInput(rows, cols, numFrames, samplesPerPixel int, b *testing.B) (*Dataset, *dicomio.Reader) {
 	b.Helper()
 	dataset := Dataset{
 		Elements: []*Element{


### PR DESCRIPTION
Making this refactor, along with other API-breaking changes being made in the next release. If users need an interface, they can create one client-side as needed for their use cases! This also matches the Writer to use a pointer struct for consistency.

This closes #319. 