### PR TITLE
Read elements with VR=UN and undefined VL as SQ

### DIFF
--- a/dataset_test.go
+++ b/dataset_test.go
@@ -24,6 +24,23 @@ func makeSequenceElement(tg tag.Tag, items [][]*Element) *Element {
 	}
 }
 
+func makeUNSequenceElement(tg tag.Tag, items [][]*Element) *Element {
+	sequenceItems := make([]*SequenceItemValue, 0, len(items))
+	for _, item := range items {
+		sequenceItems = append(sequenceItems, &SequenceItemValue{elements: item})
+	}
+
+	return &Element{
+		Tag:                    tg,
+		ValueRepresentation:    tag.VRUnknown,
+		RawValueRepresentation: "UN",
+		Value: &sequencesValue{
+			value: sequenceItems,
+		},
+		ValueLength: tag.VLUndefinedLength,
+	}
+}
+
 func TestDataset_FindElementByTag(t *testing.T) {
 	data := Dataset{
 		Elements: []*Element{

--- a/parse_test.go
+++ b/parse_test.go
@@ -100,18 +100,17 @@ func TestParseFile_SkipPixelData(t *testing.T) {
 		runForEveryTestFile(t, func(t *testing.T, filename string) {
 			dataset, err := dicom.ParseFile(filename, nil, dicom.SkipPixelData())
 			if err != nil {
-				t.Errorf("Unexpected error parsing dataset: %v", dataset)
+				t.Errorf("Unexpected error parsing dataset: %v, %v", err, dataset)
 			}
 			el, err := dataset.FindElementByTag(tag.PixelData)
-			if err != nil {
-				t.Errorf("Unexpected error when finding PixelData in Dataset: %v", err)
-			}
-			pixelData := dicom.MustGetPixelDataInfo(el.Value)
-			if !pixelData.IntentionallySkipped {
-				t.Errorf("Expected pixelData.IntentionallySkipped=true, got false")
-			}
-			if got := len(pixelData.Frames); got != 0 {
-				t.Errorf("unexpected frames length. got: %v, want: %v", got, 0)
+			if err == nil {
+				pixelData := dicom.MustGetPixelDataInfo(el.Value)
+				if !pixelData.IntentionallySkipped {
+					t.Errorf("Expected pixelData.IntentionallySkipped=true, got false")
+				}
+				if got := len(pixelData.Frames); got != 0 {
+					t.Errorf("unexpected frames length. got: %v, want: %v", got, 0)
+				}
 			}
 		})
 	})

--- a/parse_test.go
+++ b/parse_test.go
@@ -100,17 +100,18 @@ func TestParseFile_SkipPixelData(t *testing.T) {
 		runForEveryTestFile(t, func(t *testing.T, filename string) {
 			dataset, err := dicom.ParseFile(filename, nil, dicom.SkipPixelData())
 			if err != nil {
-				t.Errorf("Unexpected error parsing dataset: %v, %v", err, dataset)
+				t.Errorf("Unexpected error parsing dataset: %v", dataset)
 			}
 			el, err := dataset.FindElementByTag(tag.PixelData)
-			if err == nil {
-				pixelData := dicom.MustGetPixelDataInfo(el.Value)
-				if !pixelData.IntentionallySkipped {
-					t.Errorf("Expected pixelData.IntentionallySkipped=true, got false")
-				}
-				if got := len(pixelData.Frames); got != 0 {
-					t.Errorf("unexpected frames length. got: %v, want: %v", got, 0)
-				}
+			if err != nil {
+				t.Errorf("Unexpected error when finding PixelData in Dataset: %v", err)
+			}
+			pixelData := dicom.MustGetPixelDataInfo(el.Value)
+			if !pixelData.IntentionallySkipped {
+				t.Errorf("Expected pixelData.IntentionallySkipped=true, got false")
+			}
+			if got := len(pixelData.Frames); got != 0 {
+				t.Errorf("unexpected frames length. got: %v, want: %v", got, 0)
 			}
 		})
 	})

--- a/pkg/tag/tag.go
+++ b/pkg/tag/tag.go
@@ -130,6 +130,9 @@ const (
 	VRDate
 	// VRPixelData means the element stores a PixelDataInfo
 	VRPixelData
+	// VRUnknown means the VR of the element is unknown (possibly a private
+	// element seen while reading DICOMs in implicit transfer syntax).
+	VRUnknown
 )
 
 // GetVRKind returns the golang value encoding of an element with <tag, vr>.
@@ -144,7 +147,7 @@ func GetVRKind(tag Tag, vr string) VRKind {
 		return VRDate
 	case "AT":
 		return VRTagList
-	case "OW", "OB", "UN":
+	case "OW", "OB":
 		return VRBytes
 	case "LT", "UT":
 		return VRString
@@ -162,6 +165,8 @@ func GetVRKind(tag Tag, vr string) VRKind {
 		return VRFloat64List
 	case "SQ":
 		return VRSequence
+	case "UN":
+		return VRUnknown
 	default:
 		return VRStringList
 	}

--- a/read.go
+++ b/read.go
@@ -147,7 +147,6 @@ func (r *reader) readValue(t tag.Tag, vr string, vl uint32, isImplicit bool, d *
 	// https://github.com/suyashkumar/dicom/issues/220
 	// and
 	// https://github.com/suyashkumar/dicom/issues/231.
-	// It remains to be seen if this fits most DICOMs we see in the wild.
 	// TODO(suyashkumar): consider replacing UN VRs with SQ earlier on if they
 	// meet this criteria, so users of the Dataset can interact with it
 	// correctly.

--- a/write.go
+++ b/write.go
@@ -318,12 +318,14 @@ func verifyValueType(t tag.Tag, value Value, vr string) error {
 		ok = valueType == Sequences
 	case "NA":
 		ok = valueType == SequenceItem
-	case vrraw.OtherWord, vrraw.OtherByte, vrraw.Unknown:
+	case vrraw.OtherWord, vrraw.OtherByte:
 		if t == tag.PixelData {
 			ok = valueType == PixelData
 		} else {
 			ok = valueType == Bytes
 		}
+	case vrraw.Unknown:
+		ok = valueType == Bytes || valueType == Sequences
 	case vrraw.FloatingPointSingle, vrraw.FloatingPointDouble:
 		ok = valueType == Floats
 	default:

--- a/write_test.go
+++ b/write_test.go
@@ -51,7 +51,7 @@ func TestWrite(t *testing.T) {
 				// Some tag with an unknown VR.
 				{
 					Tag:                    tag.Tag{0x0019, 0x1027},
-					ValueRepresentation:    tag.VRBytes,
+					ValueRepresentation:    tag.VRUnknown,
 					RawValueRepresentation: "UN",
 					ValueLength:            4,
 					Value: &bytesValue{

--- a/write_test.go
+++ b/write_test.go
@@ -577,6 +577,41 @@ func TestWrite(t *testing.T) {
 			}},
 			parseOpts: []ParseOption{SkipPixelData()}, wantError: errorDeflatedTransferSyntaxUnsupported,
 		},
+		{
+			name: "nested unknown sequences",
+			dataset: Dataset{Elements: []*Element{
+				mustNewElement(tag.MediaStorageSOPClassUID, []string{"1.2.840.10008.5.1.4.1.1.1.13"}),
+				mustNewElement(tag.MediaStorageSOPInstanceUID, []string{"1.2.3.4.5.6.7"}),
+				mustNewElement(tag.TransferSyntaxUID, []string{uid.ImplicitVRLittleEndian}),
+				mustNewElement(tag.PatientName, []string{"Bob", "Jones"}),
+				makeUNSequenceElement(tag.Tag{0x0019, 0x1027}, [][]*Element{
+					// Item 1.
+					{
+						{
+							Tag:                    tag.Tag{0x0019, 0x1028},
+							ValueRepresentation:    tag.VRUnknown,
+							RawValueRepresentation: "UN",
+							Value: &bytesValue{
+								value: []byte{0x1, 0x2, 0x3, 0x4},
+							},
+						},
+						// Nested Sequence.
+						makeUNSequenceElement(tag.Tag{0x0019, 0x1029}, [][]*Element{
+							{
+								{
+									Tag:                    tag.PatientName,
+									ValueRepresentation:    tag.VRStringList,
+									RawValueRepresentation: "PN",
+									Value: &stringsValue{
+										value: []string{"Bob", "Jones"},
+									},
+								},
+							},
+						}),
+					},
+				}),
+			}},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
This addresses #220 (and one of the dicoms in #327) by treating elements with a VR=UN and undefined VL as Sequences.

This pulls from work that I and @jabillings did previously (#235).

Some follow on changes may be needed to support this part of [the spec CP](https://dicom.nema.org/dicom/cp/cp246_01.pdf):
> If at some point an application knows the actual VR for an Attribute of VR UN (e.g. has its own applicable data dictionary), it can assume that the Value Field of the Attribute is encoded in Little Endian byte ordering with implicit VR encoding, irrespective of the current TransferSyntax.
