### PR TITLE
Add WriteOption to override missing transfer syntax in dataset

### DIFF
--- a/read_test.go
+++ b/read_test.go
@@ -606,7 +606,10 @@ type headerData struct {
 // Write a collection of elements and return them as an encoded buffer of bytes.
 func writeElements(elements []*Element) ([]byte, error) {
 	buff := bytes.Buffer{}
-	dcmWriter := NewWriter(&buff)
+	dcmWriter, err := NewWriter(&buff)
+	if err != nil {
+		return []byte{}, err
+	}
 	dcmWriter.SetTransferSyntax(binary.LittleEndian, true)
 
 	for _, e := range elements {

--- a/write.go
+++ b/write.go
@@ -142,9 +142,9 @@ func DefaultMissingTransferSyntax() WriteOption {
 	}
 }
 
-// OverrideMissingTransferSyntax returns a WriteOption indicating that if
-// the dicom to be written does _not_ have a transfer syntax UID in its metadata
-// that it should be written using the provided transferSyntaxUID. A
+// OverrideMissingTransferSyntax indicates that if the Dataset to be written
+// does _not_ have a transfer syntax UID in its metadata, the Dataset should
+// be written out with the provided transfer syntax UID if possible. A
 // transfer syntax uid element with the specified transfer syntax will be
 // written to the metadata as well.
 //

--- a/write_test.go
+++ b/write_test.go
@@ -896,8 +896,8 @@ func TestWriteElement(t *testing.T) {
 	}
 }
 
-func TestWrite_OverrideMissingTransferSyntaxWith(t *testing.T) {
-	ds := Dataset{Elements: []*Element{
+func TestWrite_OverrideMissingTransferSyntax(t *testing.T) {
+	dsWithMissingTS := Dataset{Elements: []*Element{
 		mustNewElement(tag.MediaStorageSOPClassUID, []string{"1.2.840.10008.5.1.4.1.1.1.2"}),
 		mustNewElement(tag.MediaStorageSOPInstanceUID, []string{"1.2.3.4.5.6.7"}),
 		mustNewElement(tag.PatientName, []string{"Bob", "Jones"}),
@@ -927,14 +927,14 @@ func TestWrite_OverrideMissingTransferSyntaxWith(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			// Write out dicom with OverrideMissingTransferSyntax option.
 			writtenDICOM := &bytes.Buffer{}
-			if err := Write(writtenDICOM, ds, OverrideMissingTransferSyntaxWith(tc.overrideTransferSyntax)); err != nil {
-				t.Errorf("Write(OverrideMissingTransferSyntaxWith(%v)) returned unexpected error: %v", tc.overrideTransferSyntax, err)
+			if err := Write(writtenDICOM, dsWithMissingTS, OverrideMissingTransferSyntax(tc.overrideTransferSyntax)); err != nil {
+				t.Errorf("Write(OverrideMissingTransferSyntax(%v)) returned unexpected error: %v", tc.overrideTransferSyntax, err)
 			}
 
-			// Read dataset back in to see if no roundtrip errors, and also
+			// Read dataset back in to ensure no roundtrip errors, and also
 			// check that the written out transfer syntax tag matches.
-
 			parsedDS, err := ParseUntilEOF(writtenDICOM, nil)
 			if err != nil {
 				t.Fatalf("ParseUntilEOF returned unexpected error when reading written dataset back in: %v", err)
@@ -953,7 +953,6 @@ func TestWrite_OverrideMissingTransferSyntaxWith(t *testing.T) {
 			if tsVal[0] != tc.overrideTransferSyntax {
 				t.Errorf("TransferSyntaxUID in written dicom did not contain the override transfer syntax value. got: %v, want: %v", tsVal[0], tc.overrideTransferSyntax)
 			}
-
 		})
 	}
 }


### PR DESCRIPTION
This fixes #328. This change will also help set the stage for roundtrip tests for transfer syntax uid inference in the case of missing transfer syntax UIDs (part of #327). 

This also makes an API breaking change to return an error from NewWriter, which imo makes sense.

For the future:
- should we give this option as something to _always_ override whatever transfer syntax is present (or if not present, use the override as well)? 
