### PR TITLE
Attempt to fix bug in benchmark

### DIFF
--- a/.github/workflows/bench_pr.yml
+++ b/.github/workflows/bench_pr.yml
@@ -14,7 +14,7 @@ jobs:
       id: go
 
     - name: Check out code 
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Get dependencies
       run: | 
@@ -26,7 +26,13 @@ jobs:
        echo "New Commit:"
        git log -1 --format="%H"
        go test -bench=. -benchmem -benchtime=10x -count=7 > $HOME/new.txt
+       echo "Running: git reset --hard HEAD"
        git reset --hard HEAD
+       echo "DEBUG:"
+       git remote -v
+       git fetch origin $GITHUB_BASE_REF
+       git branch
+       echo "git checkout \$GITHUB_BASE_REF ($GITHUB_BASE_REF)"
        git checkout $GITHUB_BASE_REF
        echo "Base Commit:"
        git log -1 --format="%H"


### PR DESCRIPTION
Works only with `actions/checkout@v1`.

With `actions/checkout@v2`:
```
▶ Run go install golang.org/x/perf/cmd/benchstat@latest
go: downloading golang.org/x/perf v0.0.0-20240806191124-3f62[15](https://github.com/suyashkumar/dicom/actions/runs/10642057643/job/29504006392?pr=339#step:5:16)1e343c
go: downloading github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794
New Commit:
98ff6e875417e3535e2006b092594c349fff6d87
HEAD is now at 98ff6e8 Merge a734a6[16](https://github.com/suyashkumar/dicom/actions/runs/10642057643/job/29504006392?pr=339#step:5:17)a5120f4e34238665ac7ff643003528d7 into cb3864efadad3b9fd1dc331f5763bb960bc79bad
error: pathspec 'main' did not match any file(s) known to git
Error: Process completed with exit code 1.
```