### PR TITLE
Allow unknown specific character set to default to UTF-8 encoding when parsing

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -253,7 +253,7 @@ func (p *Parser) Next() (*Element, error) {
 		encodingNames := MustGetStrings(elem.Value)
 		cs, err := charset.ParseSpecificCharacterSet(encodingNames)
 		if err != nil {
-			if !p.reader.opts.allowMissingCharset {
+			if !p.reader.opts.allowUnknownCharset {
 				return nil, err
 			}
 		}
@@ -285,7 +285,7 @@ type parseOptSet struct {
 	skipPixelData                      bool
 	skipProcessingPixelDataValue       bool
 	allowMissingMetaElementGroupLength bool
-	allowMissingCharset                bool
+	allowUnknownCharset                bool
 }
 
 func toParseOptSet(opts ...ParseOption) parseOptSet {
@@ -311,10 +311,10 @@ func AllowMissingMetaElementGroupLength() ParseOption {
 	}
 }
 
-// AllowMissingCharset allows parser to ignore an error when the specific charset is not found in the default list.
-func AllowMissingCharset() ParseOption {
+// AllowUnknownCharset allows parser to ignore an error when the specific charset is not found in the default list.
+func AllowUnknownCharset() ParseOption {
 	return func(set *parseOptSet) {
-		set.allowMissingCharset = true
+		set.allowUnknownCharset = true
 	}
 }
 

--- a/parse.go
+++ b/parse.go
@@ -253,16 +253,15 @@ func (p *Parser) Next() (*Element, error) {
 		encodingNames := MustGetStrings(elem.Value)
 		cs, err := charset.ParseSpecificCharacterSet(encodingNames)
 		if err != nil {
-			// unable to parse character set, hard error
-			// TODO: add option continue, even if unable to parse
-			return nil, err
+			if !p.reader.opts.allowMissingCharset {
+				return nil, err
+			}
 		}
 		p.reader.rawReader.SetCodingSystem(cs)
 	}
 
 	p.dataset.Elements = append(p.dataset.Elements, elem)
 	return elem, nil
-
 }
 
 // GetMetadata returns just the set of metadata elements that have been parsed
@@ -286,6 +285,7 @@ type parseOptSet struct {
 	skipPixelData                      bool
 	skipProcessingPixelDataValue       bool
 	allowMissingMetaElementGroupLength bool
+	allowMissingCharset                bool
 }
 
 func toParseOptSet(opts ...ParseOption) parseOptSet {
@@ -308,6 +308,13 @@ func AllowMismatchPixelDataLength() ParseOption {
 func AllowMissingMetaElementGroupLength() ParseOption {
 	return func(set *parseOptSet) {
 		set.allowMissingMetaElementGroupLength = true
+	}
+}
+
+// AllowMissingCharset allows parser to ignore an error when the specific charset is not found in the default list.
+func AllowMissingCharset() ParseOption {
+	return func(set *parseOptSet) {
+		set.allowMissingCharset = true
 	}
 }
 

--- a/parse.go
+++ b/parse.go
@@ -252,7 +252,7 @@ func (p *Parser) Next() (*Element, error) {
 	if elem.Tag == tag.SpecificCharacterSet {
 		encodingNames := MustGetStrings(elem.Value)
 		cs, err := charset.ParseSpecificCharacterSet(encodingNames)
-		if err != nil && !p.reader.opts.allowUnknownCharset {
+		if err != nil && !p.reader.opts.allowUnknownSpecificCharacterSet {
 			return nil, err
 		}
 		p.reader.rawReader.SetCodingSystem(cs)
@@ -283,7 +283,7 @@ type parseOptSet struct {
 	skipPixelData                      bool
 	skipProcessingPixelDataValue       bool
 	allowMissingMetaElementGroupLength bool
-	allowUnknownCharset                bool
+	allowUnknownSpecificCharacterSet   bool
 }
 
 func toParseOptSet(opts ...ParseOption) parseOptSet {
@@ -309,13 +309,13 @@ func AllowMissingMetaElementGroupLength() ParseOption {
 	}
 }
 
-// AllowUnknownCharset allows the parser to ignore an error when the specific
+// AllowUnknownSpecificCharacterSet allows the parser to ignore an error when the specific
 // character set is not found in the supported character set list
 // (https://dicom.nema.org/medical/dicom/2016d/output/chtml/part02/sect_D.6.2.html).
-// Allowing the unknown charset will default to ASCII encoding.
-func AllowUnknownCharset() ParseOption {
+// Allowing the unknown specific character set will default to ASCII encoding.
+func AllowUnknownSpecificCharacterSet() ParseOption {
 	return func(set *parseOptSet) {
-		set.allowUnknownCharset = true
+		set.allowUnknownSpecificCharacterSet = true
 	}
 }
 

--- a/parse.go
+++ b/parse.go
@@ -309,8 +309,10 @@ func AllowMissingMetaElementGroupLength() ParseOption {
 	}
 }
 
-// AllowUnknownCharset allows the parser to ignore an error when the specific character set is not found in the supported character set list
-// (https://dicom.nema.org/medical/dicom/2016d/output/chtml/part02/sect_D.6.2.html). Allowing the unknown charset will default to 7bit ASCII encoding.
+// AllowUnknownCharset allows the parser to ignore an error when the specific
+// character set is not found in the supported character set list
+// (https://dicom.nema.org/medical/dicom/2016d/output/chtml/part02/sect_D.6.2.html).
+// Allowing the unknown charset will default to ASCII encoding.
 func AllowUnknownCharset() ParseOption {
 	return func(set *parseOptSet) {
 		set.allowUnknownCharset = true

--- a/parse.go
+++ b/parse.go
@@ -312,7 +312,7 @@ func AllowMissingMetaElementGroupLength() ParseOption {
 // AllowUnknownSpecificCharacterSet allows the parser to ignore an error when the specific
 // character set is not found in the supported character set list
 // (https://dicom.nema.org/medical/dicom/2016d/output/chtml/part02/sect_D.6.2.html).
-// Allowing the unknown specific character set will default to ASCII encoding.
+// Allowing the unknown specific character set will default to UTF-8 encoding.
 func AllowUnknownSpecificCharacterSet() ParseOption {
 	return func(set *parseOptSet) {
 		set.allowUnknownSpecificCharacterSet = true

--- a/parse.go
+++ b/parse.go
@@ -252,10 +252,8 @@ func (p *Parser) Next() (*Element, error) {
 	if elem.Tag == tag.SpecificCharacterSet {
 		encodingNames := MustGetStrings(elem.Value)
 		cs, err := charset.ParseSpecificCharacterSet(encodingNames)
-		if err != nil {
-			if !p.reader.opts.allowUnknownCharset {
-				return nil, err
-			}
+		if err != nil && !p.reader.opts.allowUnknownCharset {
+			return nil, err
 		}
 		p.reader.rawReader.SetCodingSystem(cs)
 	}
@@ -311,7 +309,8 @@ func AllowMissingMetaElementGroupLength() ParseOption {
 	}
 }
 
-// AllowUnknownCharset allows parser to ignore an error when the specific charset is not found in the default list.
+// AllowUnknownCharset allows the parser to ignore an error when the specific character set is not found in the supported character set list
+// (https://dicom.nema.org/medical/dicom/2016d/output/chtml/part02/sect_D.6.2.html). Allowing the unknown charset will default to 7bit ASCII encoding.
 func AllowUnknownCharset() ParseOption {
 	return func(set *parseOptSet) {
 		set.allowUnknownCharset = true

--- a/parse_test.go
+++ b/parse_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/suyashkumar/dicom/pkg/tag"
+	"github.com/suyashkumar/dicom/pkg/uid"
 
 	"github.com/suyashkumar/dicom/pkg/frame"
 
@@ -191,6 +192,49 @@ func TestParseFile_SkipProcessingPixelDataValue(t *testing.T) {
 	})
 }
 
+func TestParseFile_AllowUnknownCharset(t *testing.T) {
+	file, err := os.CreateTemp("", "unknown_charset.dcm")
+	if err != nil {
+		t.Fatalf("Unexpected error when creating tempfile: %v", err)
+	}
+
+	transferSyntaxUIDElement, err := dicom.NewElement(tag.TransferSyntaxUID, []string{uid.ImplicitVRLittleEndian})
+	if err != nil {
+		t.Fatalf("Unexpected error when creating patient name element: %v", err)
+	}
+	specificCharsetElement, err := dicom.NewElement(tag.SpecificCharacterSet, []string{"UNKNOWN"})
+	if err != nil {
+		t.Fatalf("Unexpected error when creating patient name element: %v", err)
+	}
+	patientNameElement, err := dicom.NewElement(tag.PatientName, []string{"Bob", "Jones"})
+	if err != nil {
+		t.Fatalf("Unexpected error when creating patient name element: %v", err)
+	}
+	unknownCharsetDataset := dicom.Dataset{Elements: []*dicom.Element{
+		transferSyntaxUIDElement,
+		specificCharsetElement,
+		patientNameElement,
+	}}
+	err = dicom.Write(file, unknownCharsetDataset)
+	if err != nil {
+		t.Errorf("Unexpected error writing dataset: %v", unknownCharsetDataset)
+	}
+	file.Close()
+
+	t.Run("WithoutAllowUnknownCharset", func(t *testing.T) {
+		dataset, err := dicom.ParseFile(file.Name(), nil)
+		if err == nil {
+			t.Errorf("Expected error parsing dataset: %v", dataset)
+		}
+	})
+	t.Run("WithAllowUnknownCharset", func(t *testing.T) {
+		dataset, err := dicom.ParseFile(file.Name(), nil, dicom.AllowUnknownCharset())
+		if err != nil {
+			t.Errorf("Unexpected error parsing dataset: %v", dataset)
+		}
+	})
+}
+
 // BenchmarkParse runs sanity benchmarks over the sample files in testdata.
 func BenchmarkParse(b *testing.B) {
 	cases := []struct {
@@ -218,7 +262,6 @@ func BenchmarkParse(b *testing.B) {
 			for _, f := range files {
 				if !f.IsDir() && strings.HasSuffix(f.Name(), ".dcm") {
 					b.Run(f.Name(), func(b *testing.B) {
-
 						dcm, err := os.Open("./testdata/" + f.Name())
 						if err != nil {
 							b.Errorf("Unable to open %s. Error: %v", f.Name(), err)
@@ -235,7 +278,6 @@ func BenchmarkParse(b *testing.B) {
 						for i := 0; i < b.N; i++ {
 							_, _ = dicom.Parse(bytes.NewBuffer(data), int64(len(data)), nil, tc.opts...)
 						}
-
 					})
 				}
 			}
@@ -251,7 +293,6 @@ func BenchmarkParser_NextAPI(b *testing.B) {
 	for _, f := range files {
 		if !f.IsDir() && strings.HasSuffix(f.Name(), ".dcm") {
 			b.Run(f.Name(), func(b *testing.B) {
-
 				dcm, err := os.Open("./testdata/" + f.Name())
 				if err != nil {
 					b.Errorf("Unable to open %s. Error: %v", f.Name(), err)

--- a/parse_test.go
+++ b/parse_test.go
@@ -192,8 +192,8 @@ func TestParseFile_SkipProcessingPixelDataValue(t *testing.T) {
 	})
 }
 
-func TestParseFile_AllowUnknownCharset(t *testing.T) {
-	file, err := os.CreateTemp("", "unknown_charset.dcm")
+func TestParseFile_AllowUnknownSpecificCharacterSet(t *testing.T) {
+	file, err := os.CreateTemp("", "unknown_specific_character_set.dcm")
 	if err != nil {
 		t.Fatalf("Unexpected error when creating tempfile: %v", err)
 	}
@@ -202,7 +202,7 @@ func TestParseFile_AllowUnknownCharset(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error when creating transfer syntax uid element: %v", err)
 	}
-	specificCharsetElement, err := dicom.NewElement(tag.SpecificCharacterSet, []string{"UNKNOWN"})
+	specificCharacterSetElement, err := dicom.NewElement(tag.SpecificCharacterSet, []string{"UNKNOWN"})
 	if err != nil {
 		t.Fatalf("Unexpected error when creating specific character set element: %v", err)
 	}
@@ -210,25 +210,25 @@ func TestParseFile_AllowUnknownCharset(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error when creating patient name element: %v", err)
 	}
-	unknownCharsetDataset := dicom.Dataset{Elements: []*dicom.Element{
+	unknownCharacterSetDataset := dicom.Dataset{Elements: []*dicom.Element{
 		transferSyntaxUIDElement,
-		specificCharsetElement,
+		specificCharacterSetElement,
 		patientNameElement,
 	}}
-	err = dicom.Write(file, unknownCharsetDataset)
+	err = dicom.Write(file, unknownCharacterSetDataset)
 	if err != nil {
-		t.Errorf("Unexpected error writing dataset: %v", unknownCharsetDataset)
+		t.Errorf("Unexpected error writing dataset: %v", unknownCharacterSetDataset)
 	}
 	file.Close()
 
-	t.Run("WithoutAllowUnknownCharset", func(t *testing.T) {
+	t.Run("WithoutAllowUnknownSpecificCharacterSet", func(t *testing.T) {
 		dataset, err := dicom.ParseFile(file.Name(), nil)
 		if err == nil {
 			t.Errorf("Expected error parsing dataset: %v", dataset)
 		}
 	})
-	t.Run("WithAllowUnknownCharset", func(t *testing.T) {
-		dataset, err := dicom.ParseFile(file.Name(), nil, dicom.AllowUnknownCharset())
+	t.Run("WithAllowUnknownSpecificCharacterSet", func(t *testing.T) {
+		dataset, err := dicom.ParseFile(file.Name(), nil, dicom.AllowUnknownSpecificCharacterSet())
 		if err != nil {
 			t.Errorf("Unexpected error parsing dataset: %v", dataset)
 		}

--- a/parse_test.go
+++ b/parse_test.go
@@ -200,11 +200,11 @@ func TestParseFile_AllowUnknownCharset(t *testing.T) {
 
 	transferSyntaxUIDElement, err := dicom.NewElement(tag.TransferSyntaxUID, []string{uid.ImplicitVRLittleEndian})
 	if err != nil {
-		t.Fatalf("Unexpected error when creating patient name element: %v", err)
+		t.Fatalf("Unexpected error when creating transfer syntax uid element: %v", err)
 	}
 	specificCharsetElement, err := dicom.NewElement(tag.SpecificCharacterSet, []string{"UNKNOWN"})
 	if err != nil {
-		t.Fatalf("Unexpected error when creating patient name element: %v", err)
+		t.Fatalf("Unexpected error when creating specific character set element: %v", err)
 	}
 	patientNameElement, err := dicom.NewElement(tag.PatientName, []string{"Bob", "Jones"})
 	if err != nil {

--- a/pkg/charset/charset.go
+++ b/pkg/charset/charset.go
@@ -75,16 +75,16 @@ var htmlEncodingNames = map[string]string{
 }
 
 // ParseSpecificCharacterSet converts DICOM character encoding names, such as
-// "ISO-IR 100" to encoding.Decoder(s). It will return nil, nil for the default (7bit
-// ASCII) encoding. Cf. P3.2
-// D.6.2. https://dicom.nema.org/medical/dicom/2016d/output/chtml/part02/sect_D.6.2.html
+// "ISO-IR 100" to encoding.Decoder(s). It will return nil, nil for the default (UTF-8)
+// encoding. Cf. P3.2 D.6.2.
+// https://dicom.nema.org/medical/dicom/2016d/output/chtml/part02/sect_D.6.2.html
 func ParseSpecificCharacterSet(encodingNames []string) (CodingSystem, error) {
 	var decoders []*encoding.Decoder
 	for _, name := range encodingNames {
 		var c *encoding.Decoder
 		if htmlName, ok := htmlEncodingNames[name]; !ok {
 			// TODO(saito) Support more encodings.
-			return CodingSystem{}, fmt.Errorf("ParseSpecificCharacterSet: Unknown character set '%s'. ", name)
+			return CodingSystem{}, fmt.Errorf("ParseSpecificCharacterSet: Unknown character set '%s'. Assuming utf-8", name)
 		} else {
 			if htmlName != "" {
 				d, err := htmlindex.Get(htmlName)

--- a/pkg/charset/charset.go
+++ b/pkg/charset/charset.go
@@ -84,7 +84,7 @@ func ParseSpecificCharacterSet(encodingNames []string) (CodingSystem, error) {
 		var c *encoding.Decoder
 		if htmlName, ok := htmlEncodingNames[name]; !ok {
 			// TODO(saito) Support more encodings.
-			return CodingSystem{}, fmt.Errorf("ParseSpecificCharacterSet: Unknown character set '%s'. Assuming utf-8", name)
+			return CodingSystem{}, fmt.Errorf("ParseSpecificCharacterSet: Unknown character set '%s'. ", name)
 		} else {
 			if htmlName != "" {
 				d, err := htmlindex.Get(htmlName)

--- a/pkg/dicomio/reader.go
+++ b/pkg/dicomio/reader.go
@@ -33,7 +33,7 @@ type Reader struct {
 	limitStack []int64
 	// cs represents the CodingSystem to use when reading the string. If a
 	// particular encoding.Decoder within this CodingSystem is nil, assume
-	// ASCII.
+	// UTF-8.
 	cs charset.CodingSystem
 }
 
@@ -129,7 +129,7 @@ func internalReadString(data []byte, d *encoding.Decoder) (string, error) {
 		return "", nil
 	}
 	if d == nil {
-		// Assume ASCII
+		// Assume UTF-8
 		return string(data), nil
 	}
 	bytes, err := d.Bytes(data)


### PR DESCRIPTION
This change implements an option to allow an unknown specific character set when parsing a DICOM and fallback to using UTF-8.

For context, in my application of this parser, we are seeing erroneous specific character sets such as
```
ISO IR 192
ISO_2022_IR_6
NONE
```
Current behaviour is that parsing fails immediately upon encountering an unknown character set, and the error also indicates that it will fallback to utf-8 (which is misleading since it just errors out instead of actually falling back). It seems there was a `TODO` in place for this, so this change implements the option to allow this.