### PR TITLE
Parse undefined length OB/OW elements

### DIFF
--- a/read.go
+++ b/read.go
@@ -125,7 +125,7 @@ func (r *reader) readValue(t tag.Tag, vr string, vl uint32, isImplicit bool, d *
 	switch vrkind {
 	case tag.VRBytes:
 		if vl == tag.VLUndefinedLength {
-			return r.readUndefinedLengthByteValue(t, vr)
+			return r.readUndefinedLengthByteValue()
 		}
 		return r.readBytes(t, vr, vl)
 	case tag.VRString:
@@ -162,7 +162,7 @@ func (r *reader) readValue(t tag.Tag, vr string, vl uint32, isImplicit bool, d *
 // readUndefinedLengthByteValue reads a value of type OB or OW of undefined length.
 // see https://github.com/suyashkumar/dicom/issues/349 for details.
 // pixel data should not use this and instead use readPixelData.
-func (r *reader) readUndefinedLengthByteValue(t tag.Tag, vr string) (Value, error) {
+func (r *reader) readUndefinedLengthByteValue() (Value, error) {
 	var allData []byte
 	foundDelimeter := false
 

--- a/read.go
+++ b/read.go
@@ -29,10 +29,11 @@ var (
 	// ErrorUnsupportedBitsAllocated indicates that the BitsAllocated in the
 	// NativeFrame PixelData is unsupported. In this situation, the rest of the
 	// dataset returned is still valid.
-	ErrorUnsupportedBitsAllocated = errors.New("unsupported BitsAllocated")
-	errorUnableToParseFloat       = errors.New("unable to parse float type")
-	ErrorExpectedEvenLength       = errors.New("field length is not even, in violation of DICOM spec")
-	ErrorExpectedDefinedLength    = errors.New("unable to read field of undefined length")
+	ErrorUnsupportedBitsAllocated     = errors.New("unsupported BitsAllocated")
+	errorUnableToParseFloat           = errors.New("unable to parse float type")
+	ErrorExpectedEvenLength           = errors.New("field length is not even, in violation of DICOM spec")
+	ErrorExpectedDefinedLength        = errors.New("unable to read field of undefined length")
+	ErrorExpectedSequenceDelimitation = errors.New("expected to find sequence delimitation item (fffe,e0dd)")
 )
 
 // reader is responsible for mid-level dicom parsing capabilities, like
@@ -123,6 +124,9 @@ func (r *reader) readValue(t tag.Tag, vr string, vl uint32, isImplicit bool, d *
 	// TODO: if we keep consistent function signature, consider a static map of VR to func?
 	switch vrkind {
 	case tag.VRBytes:
+		if vl == tag.VLUndefinedLength {
+			return r.readUndefinedLengthByteValue(t, vr)
+		}
 		return r.readBytes(t, vr, vl)
 	case tag.VRString:
 		return r.readString(t, vr, vl)
@@ -153,6 +157,34 @@ func (r *reader) readValue(t tag.Tag, vr string, vl uint32, isImplicit bool, d *
 	default:
 		return r.readString(t, vr, vl)
 	}
+}
+
+// readUndefinedLengthByteValue reads a value of type OB or OW of undefined length.
+// see https://github.com/suyashkumar/dicom/issues/349 for details.
+// pixel data should not use this and instead use readPixelData.
+func (r *reader) readUndefinedLengthByteValue(t tag.Tag, vr string) (Value, error) {
+	var allData []byte
+	foundDelimeter := false
+
+	for !r.rawReader.IsLimitExhausted() {
+		data, terminated, err := r.readRawItem(false)
+		if err != nil {
+			return nil, fmt.Errorf("error reading undefined byte value: %w", err)
+		}
+
+		if terminated {
+			foundDelimeter = true
+			break
+		}
+
+		allData = append(allData, data...)
+	}
+
+	if !foundDelimeter {
+		return nil, ErrorExpectedSequenceDelimitation
+	}
+
+	return &bytesValue{value: allData}, nil
 }
 
 // readHeader reads the DICOM magic header and group two metadata elements.
@@ -830,12 +862,11 @@ func (r *reader) readElement(d *Dataset, fc chan<- *frame.Frame) (*Element, erro
 	}
 
 	return &Element{Tag: *t, ValueRepresentation: tag.GetVRKind(*t, vr), RawValueRepresentation: vr, ValueLength: vl, Value: val}, nil
-
 }
 
 // Read an Item object as raw bytes, useful when parsing encapsulated PixelData.
 // This returns the read raw item, an indication if this is the end of the set
-// of items, and a possible errorawReader.
+// of items, and a possible error.
 func (r *reader) readRawItem(shouldSkip bool) ([]byte, bool, error) {
 	t, err := r.readTag()
 	if err != nil {

--- a/read.go
+++ b/read.go
@@ -32,6 +32,7 @@ var (
 	ErrorUnsupportedBitsAllocated = errors.New("unsupported BitsAllocated")
 	errorUnableToParseFloat       = errors.New("unable to parse float type")
 	ErrorExpectedEvenLength       = errors.New("field length is not even, in violation of DICOM spec")
+	ErrorExpectedDefinedLength    = errors.New("unable to read field of undefined length")
 )
 
 // reader is responsible for mid-level dicom parsing capabilities, like
@@ -641,6 +642,10 @@ func (r *reader) readSequenceItem(t tag.Tag, vr string, vl uint32, d *Dataset) (
 }
 
 func (r *reader) readBytes(t tag.Tag, vr string, vl uint32) (Value, error) {
+	if vl == tag.VLUndefinedLength {
+		return nil, ErrorExpectedDefinedLength
+	}
+
 	// TODO: add special handling of PixelData
 	if vr == vrraw.OtherByte || vr == vrraw.Unknown {
 		data := make([]byte, vl)
@@ -672,6 +677,10 @@ func (r *reader) readBytes(t tag.Tag, vr string, vl uint32) (Value, error) {
 }
 
 func (r *reader) readString(t tag.Tag, vr string, vl uint32) (Value, error) {
+	if vl == tag.VLUndefinedLength {
+		return nil, ErrorExpectedDefinedLength
+	}
+
 	str, err := r.rawReader.ReadString(vl)
 	if err != nil {
 		return nil, fmt.Errorf("error reading string element (%v) value: %w", t, err)


### PR DESCRIPTION
This addresses #349.

OB and OW fields with undefined length now parse their contents as a sequence, concatenating all the bytes in the items within.

`readBytes` and `readString` return an error if the VL is `tag.VLUndefinedLength`, as parsing these tags shouldn't fall to these, and we avoid future accidental 4GB allocations.

Trying to parse the (contrived) file from the issue now returns:
```
readElement: error when reading value for element (0049,1001): unable to read field of undefined length
```

Parsing a real DICOM file with an OB field of undefined length parses without error.

I made this a constant (`ErrorExpectedDefinedLength`) so it could be used in a test, but I think it may be worth returning a custom error so we include the VR as well, e.g. 

```
readElement: error when reading value for element (0049,1001): undefined length element of type OB cannot be read
```

