### PR TITLE
Rename testable examples to follow Go convention

### DIFF
--- a/dataset_test.go
+++ b/dataset_test.go
@@ -178,7 +178,7 @@ func ExampleDataset_FlatIterator() {
 	// (0046,0102)
 }
 
-func ExampleDataset_FlatIteratorWithExhaustAllElements() {
+func ExampleDataset_FlatIterator_withExhaust() {
 	nestedData := [][]*Element{
 		{
 			mustNewElement(tag.PatientName, []string{"Bob"}),

--- a/dataset_test.go
+++ b/dataset_test.go
@@ -178,7 +178,7 @@ func ExampleDataset_FlatIterator() {
 	// (0046,0102)
 }
 
-func ExampleDataset_FlatIterator_withExhaust() {
+func ExampleDataset_FlatIterator_withExhaustAllElements() {
 	nestedData := [][]*Element{
 		{
 			mustNewElement(tag.PatientName, []string{"Bob"}),

--- a/pkg/personname/examples_test.go
+++ b/pkg/personname/examples_test.go
@@ -86,7 +86,7 @@ func ExampleParse_partialNullSeparators() {
 }
 
 // How to create new PN value.
-func ExampleNew() {
+func ExampleInfo() {
 	// Create a new PN like so
 	pnVal := personname.Info{
 		Alphabetic: personname.GroupInfo{


### PR DESCRIPTION
In Go 1.24, `go vet` enforces correct naming on examples. This ensures our testable example names are proper. https://go.dev/doc/go1.24#vet