### PR TITLE
perf: eliminate per-iteration allocation in fillBufferSingleBitAllocated

### DIFF
--- a/read.go
+++ b/read.go
@@ -360,8 +360,8 @@ func fillBufferSingleBitAllocated(pixelData []int, d *dicomio.Reader, bo binary.
 	}
 
 	var currentByte byte
+	rawData := make([]byte, 1)
 	for i := 0; i < len(pixelData)/8; i++ {
-		rawData := make([]byte, 1)
 		_, err := d.Read(rawData)
 		if err != nil {
 			return err

--- a/read_test.go
+++ b/read_test.go
@@ -1039,6 +1039,31 @@ func BenchmarkReadNativeFrames(b *testing.B) {
 	}
 }
 
+func BenchmarkFillBufferSingleBitAllocated(b *testing.B) {
+	sizes := []struct {
+		name   string
+		pixels int
+	}{
+		{"512x512", 512 * 512},
+		{"1024x1024", 1024 * 1024},
+	}
+	for _, s := range sizes {
+		b.Run(s.name, func(b *testing.B) {
+			rawBytes := make([]byte, s.pixels/8)
+			for i := range rawBytes {
+				rawBytes[i] = byte(rand.Intn(256))
+			}
+			pixelData := make([]int, s.pixels)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				buf := bytes.NewReader(rawBytes)
+				r := dicomio.NewReader(bufio.NewReader(buf), binary.LittleEndian, int64(len(rawBytes)))
+				_ = fillBufferSingleBitAllocated(pixelData, r, binary.LittleEndian)
+			}
+		})
+	}
+}
+
 func buildReadNativeFramesInput(rows, cols, numFrames, samplesPerPixel int, b *testing.B) (*Dataset, *dicomio.Reader) {
 	b.Helper()
 	dataset := Dataset{


### PR DESCRIPTION
Move the rawData buffer allocation outside the loop so a single []byte is reused across all iterations instead of allocating once per 8-pixel group. For a 512×512 1-bit image this reduces allocs from 32,770 to 3 per call and improves throughput by ~1.6× (379µs → 233µs).

Also adds BenchmarkFillBufferSingleBitAllocated to cover this path.

| Metric | Before | After | Delta |
|---|---|---|---|
| **512×512 time** | 379 µs/op | 233 µs/op | −1.6× faster |
| **512×512 allocs** | 32,770 allocs/op | 3 allocs/op | −99.99% |
| **512×512 memory** | 36,912 B/op | 4,145 B/op | −88.8% |
| **1024×1024 time** | 1,526 µs/op | 933 µs/op | −1.6× faster |
| **1024×1024 allocs** | 131,074 allocs/op | 3 allocs/op | −99.99% |
| **1024×1024 memory** | 135,216 B/op | 4,145 B/op | −96.9% |